### PR TITLE
Allow using raw strings as Nix strings

### DIFF
--- a/nix.ncl
+++ b/nix.ncl
@@ -27,12 +27,19 @@ let contracts = {
   NixStringFragment | doc "A fragment of a Nix String"
     = contract.from_predicate predicate.is_string_fragment,
 
-  NixString | doc "A Nix string (from which a context will be deduced)"
+  NixStringWithContext | doc "A Nix string (from which a context will be deduced)"
     =
     {
       type = "nixString",
       fragments | Array NixStringFragment,
     },
+
+  NixString
+   = fun label value =>
+      if builtin.is_record value then
+        contract.apply NixStringWithContext label value
+      else
+        contract.apply Str label value,
 
   NickelDerivationType | doc m%"
       A string value to represent the type of a nickel derivation.


### PR DESCRIPTION
When something expects a Nix string but we don’t need to interpolate anything, make it possible to directly pass a raw string instead (so `"foo"` instead of `nix.lib.nix_string_hack ["foo"]`)