### PR TITLE
fix addPackage if inputName != "nixpkgs"

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -86,7 +86,7 @@ let
               if inputName == "nixpkgs" then
                 flakeInputs.${inputName}.legacyPackages.${system}
               else
-                flakeInputs.${inputName}.${system}.packages;
+                flakeInputs.${inputName}.packages.${system};
           in
           if builtins.hasAttr name input then
             acc // {"${name}" = exportForNickel input.${name};}


### PR DESCRIPTION
I have no idea if it's right.

I needed this change with `github:serokell/deploy-rs` but maybe `packages` and `system` is inverted on their side. 