### PR TITLE
Support path in inputs

### DIFF
--- a/contracts.ncl
+++ b/contracts.ncl
@@ -272,10 +272,43 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },

--- a/lib.nix
+++ b/lib.nix
@@ -95,9 +95,9 @@ let
         # filter =
       };
       fileToCall = builtins.toFile "extract-inputs.ncl" ''
-        let nix = import "${./.}/nix.ncl" in
+        let contracts = import "${./.}/contracts.ncl" in
         let nickel_expr = import "${sources}/${nickelFile}" in
-        nickel_expr.inputs_spec
+        nickel_expr.inputs_spec | {_: contracts.NickelInputSpec}
       '';
       result = runCommand "nickel-inputs.json" {} ''
         ${nickel}/bin/nickel -f ${fileToCall} export > $out

--- a/lib.nix
+++ b/lib.nix
@@ -110,45 +110,54 @@ let
   # file
   exportInputs = {system, lib, runCommand}: { declaredInputs, flakeInputs, baseDir }:
     let
-      pkgNames = builtins.attrNames declaredInputs;
-      addPackage = name: acc:
-        let inputName = declaredInputs.${name}.input; in
+      # inputId is the arbitrary name given by the Nickel expression to the
+      # input.
+      # For example,in
+      # `input_specs = {foo = {input = "nixpkgs", path = ["gcc"]}}`
+      # inputId is "foo". The package we want to get from nixpkgs is gcc.
+      #
+      # However, if no `path` is specified, `path` is taken to be `inputId`.
+      addPackage = inputId: acc:
+        let inputTakeFrom = declaredInputs.${inputId}.input; in
         # "sources" is a special type of input for files. They mimic Nix style
         # paths. We don't take them from flake inputs (where they aren't,
         # anyway), but create a simple derivation wrapper around them to pass
         # them to the Nickel side.
         # TODO: should we get rid of sources, now that we have `import_file` and
         # symbolic strings?
-        if inputName == "sources" then
+        if inputTakeFrom == "sources" then
           # TODO: could we use flakeInputs.self.outPath instead of passing
           # baseDir explicitly? Maybe, but the issue is that this path is the
           # path of the git directory, not the subdirectory of the flake.nix.
           # may need some massaging
-          let as_nix_path = baseDir + "/${declaredInputs.${name}.path}";
+          let as_nix_path = baseDir + "/${declaredInputs.${inputId}.path}";
           in
           acc // {
-            "${name}" =
+            "${inputId}" =
               exportForNickel (runCommand (builtins.baseNameOf as_nix_path) {}
               "cp -r ${as_nix_path} $out");
           }
-        else if builtins.hasAttr inputName flakeInputs then
+        else if builtins.hasAttr inputTakeFrom flakeInputs then
           let
             input =
-              if inputName == "nixpkgs" then
-                flakeInputs.${inputName}.legacyPackages.${system}
+              if inputTakeFrom == "nixpkgs" then
+                flakeInputs.${inputTakeFrom}.legacyPackages.${system}
               else
-                flakeInputs.${inputName}.packages.${system};
+                flakeInputs.${inputTakeFrom}.packages.${system};
+
+            pkgPath = declaredInputs.${inputId}.path or [inputId];
           in
-          if builtins.hasAttr name input then
-            acc // {"${name}" = exportForNickel input.${name};}
+          if lib.hasAttrByPath pkgPath input then
+            acc // {"${inputId}" = exportForNickel (lib.getAttrFromPath pkgPath input);}
           else
             builtins.throw ''
-              Could not find package `${name}` in input `${inputName}`
+              Could not find package `${builtins.concatStringsSep "." pkgPath}`
+              in input `${inputTakeFrom}`
             ''
         else
           builtins.throw ''
-            The Nickel expression requires an input `${inputName}` for package
-            `${name}`, but no such input was forwarded to importNcl on the nix
+            The Nickel expression requires an input `${inputTakeFrom}` for input
+            `${inputId}`, but no such input was forwarded to `importNcl` on the nix
             side. Forwarded inputs: ${
                  builtins.toString (builtins.attrNames flakeInputs)
               }

--- a/templates/devshells/c/contracts.ncl
+++ b/templates/devshells/c/contracts.ncl
@@ -272,10 +272,43 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },

--- a/templates/devshells/clojure/contracts.ncl
+++ b/templates/devshells/clojure/contracts.ncl
@@ -272,10 +272,43 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },

--- a/templates/devshells/erlang/contracts.ncl
+++ b/templates/devshells/erlang/contracts.ncl
@@ -272,10 +272,43 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },

--- a/templates/devshells/go/contracts.ncl
+++ b/templates/devshells/go/contracts.ncl
@@ -272,10 +272,43 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },

--- a/templates/devshells/javascript/contracts.ncl
+++ b/templates/devshells/javascript/contracts.ncl
@@ -272,10 +272,43 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },

--- a/templates/devshells/php/contracts.ncl
+++ b/templates/devshells/php/contracts.ncl
@@ -272,10 +272,43 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },

--- a/templates/devshells/python310/contracts.ncl
+++ b/templates/devshells/python310/contracts.ncl
@@ -272,10 +272,43 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },

--- a/templates/devshells/racket/contracts.ncl
+++ b/templates/devshells/racket/contracts.ncl
@@ -272,10 +272,43 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },

--- a/templates/devshells/rust/contracts.ncl
+++ b/templates/devshells/rust/contracts.ncl
@@ -272,7 +272,29 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
-  InputPath = fun label value =>
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
     if builtin.is_str value then
       string.split "." value
     else

--- a/templates/devshells/rust/contracts.ncl
+++ b/templates/devshells/rust/contracts.ncl
@@ -272,10 +272,21 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },

--- a/templates/devshells/scala/contracts.ncl
+++ b/templates/devshells/scala/contracts.ncl
@@ -272,10 +272,43 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },

--- a/templates/devshells/zig/contracts.ncl
+++ b/templates/devshells/zig/contracts.ncl
@@ -272,10 +272,43 @@ from the Nix world) or a derivation defined in Nickel.
     nix | {..},
   },
 
+  InputPath
+    | doc m%"
+        The path of a package in an input (usually nixpkgs). Can be either a
+        single attribute, represented as a string, or an array of string,
+        representing a composed path.
+
+        If a single attribute is provided (a `Str`), this contract normalizes the
+        result by splitting it around dots to obtain an array:
+
+        # Examples
+
+        ```nickel
+        "gcc" | InputPath
+          => ["gcc"]
+          => Pass the contract
+        "nodePackages.markdownlint-cli" | InputPath
+          => ["nodePackages", "markdownlint-cli"]
+          => Pass the contract
+        ["nodePackages", "markdownlint-cli"] | InputPath
+          => Pass the contract
+        ```
+    "%
+    = fun label value =>
+    if builtin.is_str value then
+      string.split "." value
+    else
+      value
+      |> contract.apply (Array Str) label,
+
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
   = {
-    input | Str
-          | default = "nixpkgs",
+    input
+      | Str
+      | default = "nixpkgs",
+    path
+      | InputPath
+      | optional,
     # TODO: precise contract. We want to allow a path if input == "sources"
     ..
   },


### PR DESCRIPTION
Closes #35. Introduce a `path` attribute in the `input_specs` schema, which can point to a composed path inside the corresponding input.

Additionally, this PR decouples the field name used in `input_specs` from the actual package, allowing to do something like:

```nickel
input_specs.my_local_gcc_alias = {
  input = "nixpkgs",
  path = "gcc",
}
```

Allowing several, independent `gcc` inputs to coexist.

This PR fixes the shebang of the `create-env.sh` scripts as well, which was using `sh` instead of `bash`.

The change has been tested, both with simple and composed paths. It turns out we didn't correctly applied the `NickelInputSpec` contract when extracting the inputs :sweat_smile: 