### PR TITLE
Use local/current nickel-nix in CI

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -61,7 +61,10 @@ jobs:
         nix flake new --template path:$PWD/repo#${{ matrix.template }} example --accept-flake-config
 
     - name: Enter devshell ${{ matrix.template }}
+      # For the CI, we test against the local version of `nickel-nix`, not the
+      # one in main (hence the --override-input). Note that each template is
+      # tested in a `./example` directory, so `nickel-nix` is the direct parent.
       run: |
           pushd ./example
-          nix develop --impure --accept-flake-config --print-build-logs
+          nix develop --impure --override-input nickel-nix path:$GITHUB_WORKSPACE --accept-flake-config --print-build-logs
           popd

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -48,17 +48,17 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        path: repo
+        path: nickel-nix-repo
         fetch-depth: 0
 
     - name: Setup
-      uses: ./repo/.github/actions/common-setup
+      uses: ./nickel-nix-repo/.github/actions/common-setup
       with:
         SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Initialize devshell ${{ matrix.template }}
       run: |
-        nix flake new --template path:$PWD/repo#${{ matrix.template }} example --accept-flake-config
+        nix flake new --template path:$PWD/nickel-nix-repo#${{ matrix.template }} example --accept-flake-config
 
     - name: Enter devshell ${{ matrix.template }}
       # For the CI, we test against the local version of `nickel-nix`, not the
@@ -66,7 +66,5 @@ jobs:
       # tested in a `./example` directory, so `nickel-nix` is the direct parent.
       run: |
           pushd ./example
-          echo "CURDIR $GITHUB_WORKSPACE"
-          find $GITHUB_WORKSPACE
-          nix develop --impure --override-input nickel-nix path:$GITHUB_WORKSPACE --accept-flake-config --print-build-logs
+          nix develop --impure --override-input nickel-nix path:$GITHUB_WORKSPACE/nickel-nix-repo --accept-flake-config --print-build-logs
           popd

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -67,6 +67,6 @@ jobs:
       run: |
           pushd ./example
           echo "CURDIR $GITHUB_WORKSPACE"
-          ls $GITHUB_WORKSPACE
+          find $GITHUB_WORKSPACE
           nix develop --impure --override-input nickel-nix path:$GITHUB_WORKSPACE --accept-flake-config --print-build-logs
           popd

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -66,5 +66,7 @@ jobs:
       # tested in a `./example` directory, so `nickel-nix` is the direct parent.
       run: |
           pushd ./example
+          echo "CURDIR $GITHUB_WORKSPACE"
+          ls $GITHUB_WORKSPACE
           nix develop --impure --override-input nickel-nix path:$GITHUB_WORKSPACE --accept-flake-config --print-build-logs
           popd


### PR DESCRIPTION
Depends on #42.

Right now, when testing the templates on the CI, we are using `nickel-nix/main` as an input. Which is an issue, as if the current PR modifies `nickel-nix/main`, this won't actually test what we want.

This PR adds `--override-input` to the CI invocation to depends on the local version of `nickel-nix` instead.