### PR TITLE
Better handling of structured_env

### DIFF
--- a/builders.ncl
+++ b/builders.ncl
@@ -1,7 +1,7 @@
 let {NickelDerivation, ..} = import "contracts.ncl" in
 
 {
-  NickelPkg 
+  NickelPkg
     # we should only need two '%%', but a current Nickel bug (#XXX) bug makes the example being
     # recognized as actual interpolation. For the time being, we thus use a
     # three '%' delimiter.
@@ -33,4 +33,217 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       ```
       "%%%
     = NickelDerivation,
+
+  BashShell = {
+    inputs_spec
+      | {
+        # default or not?
+        bash.input | priority -100 = "nixpkgs",
+        nakedStdenv.input | priority -100 = "myInputs",
+        ..
+      }
+      | default = {},
+
+    inputs,
+    nix,
+
+    output = {
+      version | default = "0.1",
+
+      # this is required otherwise nix develop
+      # will fail with a message that it only supports bash
+      build_command = {
+        cmd = s%"%{inputs.bash}/bin/bash"%,
+        args = [],
+      },
+
+      env = {
+        # TODO: handle naked derivations without having to interpolate
+        stdenv = s%"%{inputs.nakedStdenv}"%,
+      },
+    } | NickelPkg,
+  },
+
+  RustShell = BashShell & {
+    inputs_spec | {
+      cargo.input | priority -100 = "nixpkgs",
+      rustc.input | priority -100 = "nixpkgs",
+      rustfmt.input | priority -100 = "nixpkgs",
+      rust-analyzer.input | priority -100 = "nixpkgs",
+      ..
+    },
+    inputs,
+    output.structured_env = {
+      PATH = {
+        bash = s%"%{inputs.bash}/bin"%,
+        cargo = s%"%{inputs.cargo}/bin"%,
+        rustc = s%"%{inputs.rustc}/bin"%,
+        rustfmt = s%"%{inputs.rustfmt}/bin"%,
+        rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
+      },
+    },
+  },
+
+  GoShell = BashShell & {
+    inputs_spec | {
+      go.input | priority -100 = "nixpkgs",
+      gopls.input | priority -100 = "nixpkgs",
+      ..
+    },
+    inputs,
+    output.structured_env = {
+      PATH = {
+        bash = s%"%{inputs.bash}/bin"%,
+        go = s%"%{inputs.go}/bin"%,
+        gopls = s%"%{inputs.gopls}/bin"%,
+      },
+    },
+  },
+
+  ClojureShell = BashShell & {
+    inputs_spec | {
+      clojure.input | priority -100 = "nixpkgs",
+      clojure-lsp.input | priority -100 = "nixpkgs",
+      ..
+    },
+    inputs,
+    output.structured_env = {
+      PATH = {
+        bash = s%"%{inputs.bash}/bin"%,
+        clojure = s%"%{inputs.clojure}/bin"%,
+        clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
+      },
+    },
+  },
+
+  CShell = BashShell & {
+    inputs_spec | {
+      clang.input | priority -100 = "nixpkgs",
+      clang-tools.input | priority -100 = "nixpkgs",
+      ..
+    },
+    inputs,
+    output.structured_env = {
+      PATH = {
+        bash = s%"%{inputs.bash}/bin"%,
+        clang = s%"%{inputs.clang}/bin"%,
+        clang-tools = s%"%{inputs.clang-tools}/bin"%,
+      },
+    },
+  },
+
+  # intelephense is currently broken in nixpkgs
+  PhpShell = BashShell & {
+    inputs_spec | {
+      php.input | priority -100 = "nixpkgs",
+      nodePackages.intelephense.input | priority -100 = "nixpkgs",
+      ..
+    },
+    inputs,
+    output.structured_env = {
+      PATH = {
+        bash = s%"%{inputs.bash}/bin"%,
+        php = s%"%{inputs.php}/bin"%,
+        intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
+      },
+    },
+  },
+
+  ZigShell = BashShell & {
+    inputs_spec | {
+      zig.input | priority -100 = "nixpkgs",
+      zls.input | priority -100 = "nixpkgs",
+      ..
+    },
+    inputs,
+    output.structured_env = {
+      PATH = {
+        bash = s%"%{inputs.bash}/bin"%,
+        zig = s%"%{inputs.zig}/bin"%,
+        zls = s%"%{inputs.zls}/bin"%,
+      },
+    },
+  },
+
+  # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
+  JavascriptShell = BashShell & {
+    inputs_spec | {
+      nodejs.input | priority -100 = "nixpkgs",
+      nodePackages_latest.typescript-language-server.input | priority -100 = "nixpkgs",
+      ..
+    },
+    inputs,
+    output.structured_env = {
+      PATH = {
+        bash = s%"%{inputs.bash}/bin"%,
+        nodejs = s%"%{inputs.nodejs}/bin"%,
+        ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
+      },
+    },
+  },
+
+  RacketShell = BashShell & {
+    inputs_spec | {
+      racket.input | priority -100 = "nixpkgs",
+      ..
+    },
+    inputs,
+    output.structured_env = {
+      PATH = {
+        bash = s%"%{inputs.bash}/bin"%,
+        racket = s%"%{inputs.racket}/bin"%,
+      },
+    },
+  },
+
+  ScalaShell = BashShell & {
+    inputs_spec | {
+      scala.input | priority -100 = "nixpkgs",
+      metals.input | priority -100 = "nixpkgs",
+      ..
+    },
+    inputs,
+    output.structured_env = {
+      PATH = {
+        bash = s%"%{inputs.bash}/bin"%,
+        scala = s%"%{inputs.scala}/bin"%,
+        metals = s%"%{inputs.metals}/bin"%,
+      },
+    },
+  },
+
+  # broken: PyLTI-0.7.0 not supported for interpreter python3.10
+  # works with a regular nix shell though
+  Python310Shell = BashShell & {
+    inputs_spec | {
+      python310.input | priority -100 = "nixpkgs",
+      python310Packages.python-lsp-server.input | priority -100 = "nixpkgs",
+      ..
+    },
+    inputs,
+    output.structured_env = {
+      PATH = {
+        bash = s%"%{inputs.bash}/bin"%,
+        python = s%"%{inputs.python310}/bin"%,
+        python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
+      },
+    },
+  },
+
+  ErlangShell = BashShell & {
+    inputs_spec | {
+      erlang.input | priority -100 = "nixpkgs",
+      erlang-ls.input | priority -100 = "nixpkgs",
+      ..
+    },
+    inputs,
+    output.structured_env = {
+      PATH = {
+        bash = s%"%{inputs.bash}/bin"%,
+        erlang = s%"%{inputs.erlang}/bin"%,
+        erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
+      },
+    },
+  },
+
 }

--- a/contracts.ncl
+++ b/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/contracts.ncl
+++ b/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -181,9 +181,86 @@ from the Nix world) or a derivation defined in Nickel.
           cmd | NixString,
           args | Array NixString
         },
+      structured_env
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -205,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/c/builders.ncl
+++ b/templates/devshells/c/builders.ncl
@@ -82,7 +82,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   GoShell = BashShell & {
@@ -99,7 +98,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         gopls = s%"%{inputs.gopls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ClojureShell = BashShell & {
@@ -116,7 +114,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   CShell = BashShell & {
@@ -133,7 +130,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clang-tools = s%"%{inputs.clang-tools}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # intelephense is currently broken in nixpkgs
@@ -151,7 +147,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ZigShell = BashShell & {
@@ -168,7 +163,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         zls = s%"%{inputs.zls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
@@ -186,7 +180,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   RacketShell = BashShell & {
@@ -201,7 +194,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         racket = s%"%{inputs.racket}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ScalaShell = BashShell & {
@@ -218,7 +210,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         metals = s%"%{inputs.metals}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # broken: PyLTI-0.7.0 not supported for interpreter python3.10
@@ -237,7 +228,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ErlangShell = BashShell & {
@@ -254,7 +244,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
 }

--- a/templates/devshells/c/contracts.ncl
+++ b/templates/devshells/c/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/templates/devshells/c/contracts.ncl
+++ b/templates/devshells/c/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -182,11 +182,85 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc "TODO"
-        | {_: {_: NixString}},
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -208,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/c/create-env.sh
+++ b/templates/devshells/c/create-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)

--- a/templates/devshells/c/create-env.sh
+++ b/templates/devshells/c/create-env.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)
 do

--- a/templates/devshells/c/naked-stdenv.ncl
+++ b/templates/devshells/c/naked-stdenv.ncl
@@ -24,6 +24,5 @@
       "%,
       ],
     },
-    env = {},
   } | nix.builders.NickelPkg
 }

--- a/templates/devshells/clojure/builders.ncl
+++ b/templates/devshells/clojure/builders.ncl
@@ -82,7 +82,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   GoShell = BashShell & {
@@ -99,7 +98,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         gopls = s%"%{inputs.gopls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ClojureShell = BashShell & {
@@ -116,7 +114,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   CShell = BashShell & {
@@ -133,7 +130,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clang-tools = s%"%{inputs.clang-tools}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # intelephense is currently broken in nixpkgs
@@ -151,7 +147,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ZigShell = BashShell & {
@@ -168,7 +163,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         zls = s%"%{inputs.zls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
@@ -186,7 +180,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   RacketShell = BashShell & {
@@ -201,7 +194,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         racket = s%"%{inputs.racket}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ScalaShell = BashShell & {
@@ -218,7 +210,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         metals = s%"%{inputs.metals}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # broken: PyLTI-0.7.0 not supported for interpreter python3.10
@@ -237,7 +228,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ErlangShell = BashShell & {
@@ -254,7 +244,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
 }

--- a/templates/devshells/clojure/contracts.ncl
+++ b/templates/devshells/clojure/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/templates/devshells/clojure/contracts.ncl
+++ b/templates/devshells/clojure/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -182,11 +182,85 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc "TODO"
-        | {_: {_: NixString}},
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -208,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/clojure/create-env.sh
+++ b/templates/devshells/clojure/create-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)

--- a/templates/devshells/clojure/create-env.sh
+++ b/templates/devshells/clojure/create-env.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)
 do

--- a/templates/devshells/clojure/naked-stdenv.ncl
+++ b/templates/devshells/clojure/naked-stdenv.ncl
@@ -24,6 +24,5 @@
       "%,
       ],
     },
-    env = {},
   } | nix.builders.NickelPkg
 }

--- a/templates/devshells/erlang/builders.ncl
+++ b/templates/devshells/erlang/builders.ncl
@@ -82,7 +82,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   GoShell = BashShell & {
@@ -99,7 +98,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         gopls = s%"%{inputs.gopls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ClojureShell = BashShell & {
@@ -116,7 +114,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   CShell = BashShell & {
@@ -133,7 +130,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clang-tools = s%"%{inputs.clang-tools}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # intelephense is currently broken in nixpkgs
@@ -151,7 +147,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ZigShell = BashShell & {
@@ -168,7 +163,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         zls = s%"%{inputs.zls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
@@ -186,7 +180,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   RacketShell = BashShell & {
@@ -201,7 +194,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         racket = s%"%{inputs.racket}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ScalaShell = BashShell & {
@@ -218,7 +210,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         metals = s%"%{inputs.metals}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # broken: PyLTI-0.7.0 not supported for interpreter python3.10
@@ -237,7 +228,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ErlangShell = BashShell & {
@@ -254,7 +244,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
 }

--- a/templates/devshells/erlang/contracts.ncl
+++ b/templates/devshells/erlang/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/templates/devshells/erlang/contracts.ncl
+++ b/templates/devshells/erlang/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -182,11 +182,85 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc "TODO"
-        | {_: {_: NixString}},
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -208,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/erlang/create-env.sh
+++ b/templates/devshells/erlang/create-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)

--- a/templates/devshells/erlang/create-env.sh
+++ b/templates/devshells/erlang/create-env.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)
 do

--- a/templates/devshells/erlang/naked-stdenv.ncl
+++ b/templates/devshells/erlang/naked-stdenv.ncl
@@ -24,6 +24,5 @@
       "%,
       ],
     },
-    env = {},
   } | nix.builders.NickelPkg
 }

--- a/templates/devshells/go/builders.ncl
+++ b/templates/devshells/go/builders.ncl
@@ -82,7 +82,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   GoShell = BashShell & {
@@ -99,7 +98,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         gopls = s%"%{inputs.gopls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ClojureShell = BashShell & {
@@ -116,7 +114,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   CShell = BashShell & {
@@ -133,7 +130,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clang-tools = s%"%{inputs.clang-tools}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # intelephense is currently broken in nixpkgs
@@ -151,7 +147,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ZigShell = BashShell & {
@@ -168,7 +163,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         zls = s%"%{inputs.zls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
@@ -186,7 +180,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   RacketShell = BashShell & {
@@ -201,7 +194,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         racket = s%"%{inputs.racket}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ScalaShell = BashShell & {
@@ -218,7 +210,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         metals = s%"%{inputs.metals}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # broken: PyLTI-0.7.0 not supported for interpreter python3.10
@@ -237,7 +228,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ErlangShell = BashShell & {
@@ -254,7 +244,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
 }

--- a/templates/devshells/go/contracts.ncl
+++ b/templates/devshells/go/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/templates/devshells/go/contracts.ncl
+++ b/templates/devshells/go/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -182,11 +182,85 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc "TODO"
-        | {_: {_: NixString}},
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -208,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/go/create-env.sh
+++ b/templates/devshells/go/create-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)

--- a/templates/devshells/go/create-env.sh
+++ b/templates/devshells/go/create-env.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)
 do

--- a/templates/devshells/go/naked-stdenv.ncl
+++ b/templates/devshells/go/naked-stdenv.ncl
@@ -24,6 +24,5 @@
       "%,
       ],
     },
-    env = {},
   } | nix.builders.NickelPkg
 }

--- a/templates/devshells/javascript/builders.ncl
+++ b/templates/devshells/javascript/builders.ncl
@@ -82,7 +82,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   GoShell = BashShell & {
@@ -99,7 +98,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         gopls = s%"%{inputs.gopls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ClojureShell = BashShell & {
@@ -116,7 +114,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   CShell = BashShell & {
@@ -133,7 +130,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clang-tools = s%"%{inputs.clang-tools}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # intelephense is currently broken in nixpkgs
@@ -151,7 +147,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ZigShell = BashShell & {
@@ -168,7 +163,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         zls = s%"%{inputs.zls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
@@ -186,7 +180,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   RacketShell = BashShell & {
@@ -201,7 +194,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         racket = s%"%{inputs.racket}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ScalaShell = BashShell & {
@@ -218,7 +210,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         metals = s%"%{inputs.metals}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # broken: PyLTI-0.7.0 not supported for interpreter python3.10
@@ -237,7 +228,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ErlangShell = BashShell & {
@@ -254,7 +244,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
 }

--- a/templates/devshells/javascript/contracts.ncl
+++ b/templates/devshells/javascript/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/templates/devshells/javascript/contracts.ncl
+++ b/templates/devshells/javascript/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -182,11 +182,85 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc "TODO"
-        | {_: {_: NixString}},
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -208,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/javascript/create-env.sh
+++ b/templates/devshells/javascript/create-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)

--- a/templates/devshells/javascript/create-env.sh
+++ b/templates/devshells/javascript/create-env.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)
 do

--- a/templates/devshells/javascript/naked-stdenv.ncl
+++ b/templates/devshells/javascript/naked-stdenv.ncl
@@ -24,6 +24,5 @@
       "%,
       ],
     },
-    env = {},
   } | nix.builders.NickelPkg
 }

--- a/templates/devshells/php/builders.ncl
+++ b/templates/devshells/php/builders.ncl
@@ -82,7 +82,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   GoShell = BashShell & {
@@ -99,7 +98,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         gopls = s%"%{inputs.gopls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ClojureShell = BashShell & {
@@ -116,7 +114,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   CShell = BashShell & {
@@ -133,7 +130,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clang-tools = s%"%{inputs.clang-tools}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # intelephense is currently broken in nixpkgs
@@ -151,7 +147,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ZigShell = BashShell & {
@@ -168,7 +163,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         zls = s%"%{inputs.zls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
@@ -186,7 +180,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   RacketShell = BashShell & {
@@ -201,7 +194,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         racket = s%"%{inputs.racket}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ScalaShell = BashShell & {
@@ -218,7 +210,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         metals = s%"%{inputs.metals}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # broken: PyLTI-0.7.0 not supported for interpreter python3.10
@@ -237,7 +228,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ErlangShell = BashShell & {
@@ -254,7 +244,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
 }

--- a/templates/devshells/php/contracts.ncl
+++ b/templates/devshells/php/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/templates/devshells/php/contracts.ncl
+++ b/templates/devshells/php/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -182,11 +182,85 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc "TODO"
-        | {_: {_: NixString}},
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -208,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/php/create-env.sh
+++ b/templates/devshells/php/create-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)

--- a/templates/devshells/php/create-env.sh
+++ b/templates/devshells/php/create-env.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)
 do

--- a/templates/devshells/php/naked-stdenv.ncl
+++ b/templates/devshells/php/naked-stdenv.ncl
@@ -24,6 +24,5 @@
       "%,
       ],
     },
-    env = {},
   } | nix.builders.NickelPkg
 }

--- a/templates/devshells/python310/builders.ncl
+++ b/templates/devshells/python310/builders.ncl
@@ -82,7 +82,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   GoShell = BashShell & {
@@ -99,7 +98,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         gopls = s%"%{inputs.gopls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ClojureShell = BashShell & {
@@ -116,7 +114,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   CShell = BashShell & {
@@ -133,7 +130,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clang-tools = s%"%{inputs.clang-tools}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # intelephense is currently broken in nixpkgs
@@ -151,7 +147,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ZigShell = BashShell & {
@@ -168,7 +163,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         zls = s%"%{inputs.zls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
@@ -186,7 +180,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   RacketShell = BashShell & {
@@ -201,7 +194,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         racket = s%"%{inputs.racket}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ScalaShell = BashShell & {
@@ -218,7 +210,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         metals = s%"%{inputs.metals}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # broken: PyLTI-0.7.0 not supported for interpreter python3.10
@@ -237,7 +228,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ErlangShell = BashShell & {
@@ -254,7 +244,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
 }

--- a/templates/devshells/python310/contracts.ncl
+++ b/templates/devshells/python310/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/templates/devshells/python310/contracts.ncl
+++ b/templates/devshells/python310/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -182,11 +182,85 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc "TODO"
-        | {_: {_: NixString}},
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -208,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/python310/create-env.sh
+++ b/templates/devshells/python310/create-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)

--- a/templates/devshells/python310/create-env.sh
+++ b/templates/devshells/python310/create-env.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)
 do

--- a/templates/devshells/python310/naked-stdenv.ncl
+++ b/templates/devshells/python310/naked-stdenv.ncl
@@ -24,6 +24,5 @@
       "%,
       ],
     },
-    env = {},
   } | nix.builders.NickelPkg
 }

--- a/templates/devshells/racket/builders.ncl
+++ b/templates/devshells/racket/builders.ncl
@@ -82,7 +82,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   GoShell = BashShell & {
@@ -99,7 +98,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         gopls = s%"%{inputs.gopls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ClojureShell = BashShell & {
@@ -116,7 +114,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   CShell = BashShell & {
@@ -133,7 +130,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clang-tools = s%"%{inputs.clang-tools}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # intelephense is currently broken in nixpkgs
@@ -151,7 +147,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ZigShell = BashShell & {
@@ -168,7 +163,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         zls = s%"%{inputs.zls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
@@ -186,7 +180,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   RacketShell = BashShell & {
@@ -201,7 +194,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         racket = s%"%{inputs.racket}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ScalaShell = BashShell & {
@@ -218,7 +210,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         metals = s%"%{inputs.metals}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # broken: PyLTI-0.7.0 not supported for interpreter python3.10
@@ -237,7 +228,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ErlangShell = BashShell & {
@@ -254,7 +244,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
 }

--- a/templates/devshells/racket/contracts.ncl
+++ b/templates/devshells/racket/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/templates/devshells/racket/contracts.ncl
+++ b/templates/devshells/racket/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -182,11 +182,85 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc "TODO"
-        | {_: {_: NixString}},
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -208,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/racket/create-env.sh
+++ b/templates/devshells/racket/create-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)

--- a/templates/devshells/racket/create-env.sh
+++ b/templates/devshells/racket/create-env.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)
 do

--- a/templates/devshells/racket/naked-stdenv.ncl
+++ b/templates/devshells/racket/naked-stdenv.ncl
@@ -24,6 +24,5 @@
       "%,
       ],
     },
-    env = {},
   } | nix.builders.NickelPkg
 }

--- a/templates/devshells/rust/builders.ncl
+++ b/templates/devshells/rust/builders.ncl
@@ -82,7 +82,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   GoShell = BashShell & {
@@ -99,7 +98,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         gopls = s%"%{inputs.gopls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ClojureShell = BashShell & {
@@ -116,7 +114,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   CShell = BashShell & {
@@ -133,7 +130,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clang-tools = s%"%{inputs.clang-tools}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # intelephense is currently broken in nixpkgs
@@ -151,7 +147,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ZigShell = BashShell & {
@@ -168,7 +163,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         zls = s%"%{inputs.zls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
@@ -186,7 +180,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   RacketShell = BashShell & {
@@ -201,7 +194,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         racket = s%"%{inputs.racket}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ScalaShell = BashShell & {
@@ -218,7 +210,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         metals = s%"%{inputs.metals}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # broken: PyLTI-0.7.0 not supported for interpreter python3.10
@@ -237,7 +228,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ErlangShell = BashShell & {
@@ -254,7 +244,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
 }

--- a/templates/devshells/rust/contracts.ncl
+++ b/templates/devshells/rust/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/templates/devshells/rust/contracts.ncl
+++ b/templates/devshells/rust/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -182,11 +182,85 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc "TODO"
-        | {_: {_: NixString}},
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -208,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/rust/create-env.sh
+++ b/templates/devshells/rust/create-env.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-
+#!/usr/bin/env bash
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)
 do

--- a/templates/devshells/rust/naked-stdenv.ncl
+++ b/templates/devshells/rust/naked-stdenv.ncl
@@ -24,6 +24,5 @@
       "%,
       ],
     },
-    env = {},
   } | nix.builders.NickelPkg
 }

--- a/templates/devshells/scala/builders.ncl
+++ b/templates/devshells/scala/builders.ncl
@@ -82,7 +82,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   GoShell = BashShell & {
@@ -99,7 +98,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         gopls = s%"%{inputs.gopls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ClojureShell = BashShell & {
@@ -116,7 +114,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   CShell = BashShell & {
@@ -133,7 +130,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clang-tools = s%"%{inputs.clang-tools}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # intelephense is currently broken in nixpkgs
@@ -151,7 +147,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ZigShell = BashShell & {
@@ -168,7 +163,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         zls = s%"%{inputs.zls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
@@ -186,7 +180,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   RacketShell = BashShell & {
@@ -201,7 +194,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         racket = s%"%{inputs.racket}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ScalaShell = BashShell & {
@@ -218,7 +210,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         metals = s%"%{inputs.metals}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # broken: PyLTI-0.7.0 not supported for interpreter python3.10
@@ -237,7 +228,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ErlangShell = BashShell & {
@@ -254,7 +244,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
 }

--- a/templates/devshells/scala/contracts.ncl
+++ b/templates/devshells/scala/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/templates/devshells/scala/contracts.ncl
+++ b/templates/devshells/scala/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -182,11 +182,85 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc "TODO"
-        | {_: {_: NixString}},
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -208,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/scala/create-env.sh
+++ b/templates/devshells/scala/create-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)

--- a/templates/devshells/scala/create-env.sh
+++ b/templates/devshells/scala/create-env.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)
 do

--- a/templates/devshells/scala/naked-stdenv.ncl
+++ b/templates/devshells/scala/naked-stdenv.ncl
@@ -24,6 +24,5 @@
       "%,
       ],
     },
-    env = {},
   } | nix.builders.NickelPkg
 }

--- a/templates/devshells/zig/builders.ncl
+++ b/templates/devshells/zig/builders.ncl
@@ -82,7 +82,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         rust-analyzer = s%"%{inputs.rust-analyzer}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   GoShell = BashShell & {
@@ -99,7 +98,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         gopls = s%"%{inputs.gopls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ClojureShell = BashShell & {
@@ -116,7 +114,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clojure-lsp = s%"%{inputs.clojure-lsp}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   CShell = BashShell & {
@@ -133,7 +130,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         clang-tools = s%"%{inputs.clang-tools}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # intelephense is currently broken in nixpkgs
@@ -151,7 +147,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         intelephense = s%"%{inputs.nodePackages_latest.intelephense}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ZigShell = BashShell & {
@@ -168,7 +163,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         zls = s%"%{inputs.zls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # nodePackages_latest.typescript-language-server is marked broken in nixpkgs
@@ -186,7 +180,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         ts-lsp = s%"%{inputs.nodePackages_latest.typescript-language-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   RacketShell = BashShell & {
@@ -201,7 +194,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         racket = s%"%{inputs.racket}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ScalaShell = BashShell & {
@@ -218,7 +210,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         metals = s%"%{inputs.metals}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   # broken: PyLTI-0.7.0 not supported for interpreter python3.10
@@ -237,7 +228,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         python-lsp = s%"%{inputs.python310Packages.python-lsp-server}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
   ErlangShell = BashShell & {
@@ -254,7 +244,6 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         erlang-lsp = s%"%{inputs.erlang-ls}/bin"%,
       },
     },
-    output.env = record.map (fun _n xs => array.foldl (fun acc x => s%"%{acc}:%{x}"%) "" (record.values xs)) output.structured_env,
   },
 
 }

--- a/templates/devshells/zig/contracts.ncl
+++ b/templates/devshells/zig/contracts.ncl
@@ -182,7 +182,7 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc m%%"
+        | doc m%%%"
             Set additional environment variables for the builder.
 
             `structured_env` is usually preferred over `env`, as the former is
@@ -240,7 +240,7 @@ from the Nix world) or a derivation defined in Nickel.
             value of `env` is built from `structured_env` automatically. If you
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
-          "%%
+          "%%%
         | {_: {_: NixString}}
         | default = {},
       env

--- a/templates/devshells/zig/contracts.ncl
+++ b/templates/devshells/zig/contracts.ncl
@@ -152,9 +152,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelDerivation
     | doc m%"
-        The basic, low-level interface for a symbolic derivation. A NickelPkg is
-        intenteded to be passed (exported) to the Nix side, which will take care
-        of actually building it.
+        The basic, low-level interface for a symbolic derivation. A
+        NickelDerivation is intenteded to be passed (exported) to the Nix side,
+        which will take care of actually building it.
       "%
     = {
       name
@@ -182,11 +182,85 @@ from the Nix world) or a derivation defined in Nickel.
           args | Array NixString
         },
       structured_env
-        | doc "TODO"
-        | {_: {_: NixString}},
+        | doc m%%"
+            Set additional environment variables for the builder.
+
+            `structured_env` is usually preferred over `env`, as the former is
+            easier to merge and to override.
+
+
+            # Format
+
+            `structured_env` is a record whose fields are environment variables
+            (`PATH`, `CLASSPATH`, `LD_PRELOAD`, etc.). The values are records
+            themselves, which represents _named pieces_ that are joined together
+            to form the final value of the variable.
+
+            For example:
+
+            ```nickel
+            structured_env.PATH = {
+              bash = nix-s%"%{inputs.bash}/bin"%,
+              curl = nix-s%"%{inputs.curl}/bin"%,
+            }
+            ```
+
+            This structured environment corresponds to a variable `PATH` with
+            value `"%{inputs.bash}/bin:%{inputs.curl}/bin"`. Note that the order
+            isn't preserved. The `bash` and `curl` names don't appear in the
+            final value, but they are used for composability and overriding.
+
+            ## Combining
+
+            For example, imagine defining a shell in two different records, that
+            are merged together: `builder1 & builder2`. `builder1` defines the
+            structured environment given in the example above. Because
+            `structured_env.PATH` is a recod, you can simply write in
+            `builder2.ncl`:
+
+            ```nickel
+            structured_env.PATH.other-package = nix-s"%{inputs.other-package}/bin"%,
+            ```
+
+            The final result will be a path with all three subpaths separated by
+            `:`.
+
+            ## Overriding
+
+            Because pieces are named (`bash`, `curl`, `other-package`), you can
+            override them specifically using merging:
+
+            ```nickel
+            structured_env.PATH.bash | force = nix-s"%{inputs.special-bash}/bin"%,
+            ```
+
+            # Interaction with `env`
+
+            Usually, you should only work with `structured_env`. The default
+            value of `env` is built from `structured_env` automatically. If you
+            override `env` directly, be aware that **`structured_env` will then
+            be potentially completly ignored**.
+          "%%
+        | {_: {_: NixString}}
+        | default = {},
       env
-        | doc "Set additional environment variables for the builder."
-        | {_: NixString},
+        | doc m%"
+          Set additional environment variables for the builder.
+
+          By default, `env` is computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the
+          actual source of truth being passed to Nix when building the
+          derivation. See the documentation of `structured_env` for more
+          details.
+          "%
+        | {_: NixString}
+        | default = record.map
+            (fun _n xs =>
+              record.values xs
+              # I guess we don't necessarily always want to use `:` as a
+              # separator?
+              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
+            structured_env,
       "%{type_field}" | force = "nickelDerivation",
   },
 
@@ -208,8 +282,9 @@ from the Nix world) or a derivation defined in Nickel.
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
-  # still obey some rules: if the `type` field is set to a known predefined
+  # it still obeys some rules: if the `type` field is set to a known predefined
   # value, then the record must have a certain shape.
+  #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
   NickelExpressionResult = Dyn,

--- a/templates/devshells/zig/create-env.sh
+++ b/templates/devshells/zig/create-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)

--- a/templates/devshells/zig/create-env.sh
+++ b/templates/devshells/zig/create-env.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 
 for devenv in $(awk '/= BashShell/ { print $1 }' builders.ncl)
 do

--- a/templates/devshells/zig/naked-stdenv.ncl
+++ b/templates/devshells/zig/naked-stdenv.ncl
@@ -24,6 +24,5 @@
       "%,
       ],
     },
-    env = {},
   } | nix.builders.NickelPkg
 }


### PR DESCRIPTION
The code for computing  `env` from `structured_env` is duplicated in each and every builders: this PR moves this duplicated code directly to the `NickelDerivation` contract instead.

It also adds a more in-depth documentation of `structured_env`, `env` and their relation, and provides sensible default values as well. The lack of default value for `env` was making naked-stdenv to fail the contract.
