### PR TITLE
Restore correct environment

### DIFF
--- a/builders.ncl
+++ b/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,24 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
+      structured_env.stdenv = {
         # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/contracts.ncl
+++ b/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/c/builders.ncl
+++ b/templates/devshells/c/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,23 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
-        # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+      structured_env.stdenv = {
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/templates/devshells/c/contracts.ncl
+++ b/templates/devshells/c/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/c/flake.nix
+++ b/templates/devshells/c/flake.nix
@@ -25,7 +25,7 @@
         (
           inputs
           // {
-            myInputs.packages.${system} = {inherit nakedStdenv;};
+            nixel-internals.packages.${system} = {naked_std_env = nakedStdenv;};
           }
         );
     in rec {

--- a/templates/devshells/clojure/builders.ncl
+++ b/templates/devshells/clojure/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,23 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
-        # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+      structured_env.stdenv = {
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/templates/devshells/clojure/contracts.ncl
+++ b/templates/devshells/clojure/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/clojure/flake.nix
+++ b/templates/devshells/clojure/flake.nix
@@ -25,7 +25,7 @@
         (
           inputs
           // {
-            myInputs.packages.${system} = {inherit nakedStdenv;};
+            nixel-internals.packages.${system} = {naked_std_env = nakedStdenv;};
           }
         );
     in rec {

--- a/templates/devshells/erlang/builders.ncl
+++ b/templates/devshells/erlang/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,23 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
-        # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+      structured_env.stdenv = {
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/templates/devshells/erlang/contracts.ncl
+++ b/templates/devshells/erlang/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/erlang/flake.nix
+++ b/templates/devshells/erlang/flake.nix
@@ -25,7 +25,7 @@
         (
           inputs
           // {
-            myInputs.packages.${system} = {inherit nakedStdenv;};
+            nixel-internals.packages.${system} = {naked_std_env = nakedStdenv;};
           }
         );
     in rec {

--- a/templates/devshells/go/builders.ncl
+++ b/templates/devshells/go/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,23 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
-        # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+      structured_env.stdenv = {
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/templates/devshells/go/contracts.ncl
+++ b/templates/devshells/go/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/go/flake.nix
+++ b/templates/devshells/go/flake.nix
@@ -25,7 +25,7 @@
         (
           inputs
           // {
-            myInputs.packages.${system} = {inherit nakedStdenv;};
+            nixel-internals.packages.${system} = {naked_std_env = nakedStdenv;};
           }
         );
     in rec {

--- a/templates/devshells/javascript/builders.ncl
+++ b/templates/devshells/javascript/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,23 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
-        # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+      structured_env.stdenv = {
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/templates/devshells/javascript/contracts.ncl
+++ b/templates/devshells/javascript/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/javascript/flake.nix
+++ b/templates/devshells/javascript/flake.nix
@@ -25,7 +25,7 @@
         (
           inputs
           // {
-            myInputs.packages.${system} = {inherit nakedStdenv;};
+            nixel-internals.packages.${system} = {naked_std_env = nakedStdenv;};
           }
         );
     in rec {

--- a/templates/devshells/php/builders.ncl
+++ b/templates/devshells/php/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,23 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
-        # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+      structured_env.stdenv = {
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/templates/devshells/php/contracts.ncl
+++ b/templates/devshells/php/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/php/flake.nix
+++ b/templates/devshells/php/flake.nix
@@ -25,7 +25,7 @@
         (
           inputs
           // {
-            myInputs.packages.${system} = {inherit nakedStdenv;};
+            nixel-internals.packages.${system} = {naked_std_env = nakedStdenv;};
           }
         );
     in rec {

--- a/templates/devshells/python310/builders.ncl
+++ b/templates/devshells/python310/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,23 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
-        # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+      structured_env.stdenv = {
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/templates/devshells/python310/contracts.ncl
+++ b/templates/devshells/python310/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/python310/flake.nix
+++ b/templates/devshells/python310/flake.nix
@@ -25,7 +25,7 @@
         (
           inputs
           // {
-            myInputs.packages.${system} = {inherit nakedStdenv;};
+            nixel-internals.packages.${system} = {naked_std_env = nakedStdenv;};
           }
         );
     in rec {

--- a/templates/devshells/racket/builders.ncl
+++ b/templates/devshells/racket/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,23 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
-        # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+      structured_env.stdenv = {
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/templates/devshells/racket/contracts.ncl
+++ b/templates/devshells/racket/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/racket/flake.nix
+++ b/templates/devshells/racket/flake.nix
@@ -25,7 +25,7 @@
         (
           inputs
           // {
-            myInputs.packages.${system} = {inherit nakedStdenv;};
+            nixel-internals.packages.${system} = {naked_std_env = nakedStdenv;};
           }
         );
     in rec {

--- a/templates/devshells/rust/builders.ncl
+++ b/templates/devshells/rust/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,23 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
-        # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+      structured_env.stdenv = {
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/templates/devshells/rust/contracts.ncl
+++ b/templates/devshells/rust/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/rust/flake.nix
+++ b/templates/devshells/rust/flake.nix
@@ -25,7 +25,7 @@
         (
           inputs
           // {
-            myInputs.packages.${system} = {inherit nakedStdenv;};
+            nixel-internals.packages.${system} = {naked_std_env = nakedStdenv;};
           }
         );
     in rec {

--- a/templates/devshells/scala/builders.ncl
+++ b/templates/devshells/scala/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,23 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
-        # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+      structured_env.stdenv = {
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/templates/devshells/scala/contracts.ncl
+++ b/templates/devshells/scala/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/scala/flake.nix
+++ b/templates/devshells/scala/flake.nix
@@ -25,7 +25,7 @@
         (
           inputs
           // {
-            myInputs.packages.${system} = {inherit nakedStdenv;};
+            nixel-internals.packages.${system} = {naked_std_env = nakedStdenv;};
           }
         );
     in rec {

--- a/templates/devshells/zig/builders.ncl
+++ b/templates/devshells/zig/builders.ncl
@@ -39,7 +39,7 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
       | {
         # default or not?
         bash.input | priority -100 = "nixpkgs",
-        nakedStdenv.input | priority -100 = "myInputs",
+        naked_std_env.input | priority -100 = "nixel-internals",
         ..
       }
       | default = {},
@@ -57,10 +57,23 @@ let {NickelDerivation, ..} = import "contracts.ncl" in
         args = [],
       },
 
-      env = {
-        # TODO: handle naked derivations without having to interpolate
-        stdenv = s%"%{inputs.nakedStdenv}"%,
+      structured_env.stdenv = {
+        naked_std_env = s%"%{inputs.naked_std_env}"%,
       },
+      
+      # Compute `env` from `structured_env`. Note that thanks to recursive
+      # overriding, if stuff is added to `structured_env` through merging,
+      # `env` will be automatically up-to-date
+      env =
+        structured_env
+        |> record.map (fun _n xs =>
+          # Intersperse ':' between environment variable fragments
+          let values = record.values xs in
+          let first = array.head values in
+          values
+          |> array.tail
+          |> array.foldl (fun acc value => s%"%{acc}:%{value}"%) first
+        ),
     } | NickelPkg,
   },
 

--- a/templates/devshells/zig/contracts.ncl
+++ b/templates/devshells/zig/contracts.ncl
@@ -247,23 +247,22 @@ from the Nix world) or a derivation defined in Nickel.
         | doc m%"
           Set additional environment variables for the builder.
 
-          By default, `env` is computed from `structured_env`, and
-          `structured_env` should be used preferably. Ultimately, `env` is the
-          actual source of truth being passed to Nix when building the
-          derivation. See the documentation of `structured_env` for more
-          details.
+          By default, `env` should computed from `structured_env`, and
+          `structured_env` should be used preferably. Ultimately, `env` is the actual
+          source of truth being passed to Nix when building the derivation. See the
+          documentation of `structured_env` for more details.
           "%
         | {_: NixString}
-        | default = record.map
-            (fun _n xs =>
-              record.values xs
-              # I guess we don't necessarily always want to use `:` as a
-              # separator?
-              |> array.foldl (fun acc x => s%"%{acc}:%{x}"%) "")
-            structured_env,
+        # TODO: should we compute `env` from `structured_env` directly here? Or
+        # let each builder do that by itself?
+        #
+        # Some parameters, like the separator, may vary. For now we have no
+        # choice anyway, because of merging not being idempotent on complex
+        # values, and because the `NickelDerivation` contract is applied several
+        # times, we have to move the computing logic to builders.
+        | default = {},
       "%{type_field}" | force = "nickelDerivation",
   },
-
 
   Params | doc "The parameters provided to the Nickel expression"
     = {

--- a/templates/devshells/zig/flake.nix
+++ b/templates/devshells/zig/flake.nix
@@ -25,7 +25,7 @@
         (
           inputs
           // {
-            myInputs.packages.${system} = {inherit nakedStdenv;};
+            nixel-internals.packages.${system} = {naked_std_env = nakedStdenv;};
           }
         );
     in rec {


### PR DESCRIPTION
A previous PR (#45) made the usage and structure of `structured_env` simpler. However, the effects wasn't the expected one, as the `PATH` became unset in the development shell. It seems the right fix would be to get rid of `env` altogether in the builders, and delegate environment building to `NickelDerivation`.

Unfortunately, `NickelDerivation` ends up being applied several times, and it's not idempotent (Nickel currently refuses to merge arrays together, hence the computed value for `env` fails to merge with itself).

We fix the previous bug, and move the computation of `env` to `BashShell` in the meantime (waiting for Nickel to be smarter about merging identical values).