### PR TITLE
Make "system" attribute optional for derivations

### DIFF
--- a/contracts.ncl
+++ b/contracts.ncl
@@ -184,9 +184,9 @@ from the Nix world) or a derivation defined in Nickel.
         | Array Derivation
         | default = [],
       system
-        | doc "The system to build the package on."
+        | doc "The system to build the package on. Defaults to the system used by importNcl."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/examples/c-hello-world/nixel/contracts.ncl
+++ b/examples/c-hello-world/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/templates/devshells/c/nixel/contracts.ncl
+++ b/templates/devshells/c/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/templates/devshells/clojure/nixel/contracts.ncl
+++ b/templates/devshells/clojure/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/templates/devshells/erlang/nixel/contracts.ncl
+++ b/templates/devshells/erlang/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/templates/devshells/go/nixel/contracts.ncl
+++ b/templates/devshells/go/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/templates/devshells/javascript/nixel/contracts.ncl
+++ b/templates/devshells/javascript/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/templates/devshells/php/nixel/contracts.ncl
+++ b/templates/devshells/php/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/templates/devshells/python310/nixel/contracts.ncl
+++ b/templates/devshells/python310/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/templates/devshells/racket/nixel/contracts.ncl
+++ b/templates/devshells/racket/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/templates/devshells/rust/nixel/contracts.ncl
+++ b/templates/devshells/rust/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/templates/devshells/scala/nixel/contracts.ncl
+++ b/templates/devshells/scala/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {

--- a/templates/devshells/zig/nixel/contracts.ncl
+++ b/templates/devshells/zig/nixel/contracts.ncl
@@ -186,7 +186,7 @@ from the Nix world) or a derivation defined in Nickel.
       system
         | doc "The system to build the package on."
         | System
-        | default = {arch = "x86_64", os = "linux"},
+        | optional,
       build_command
         | doc "The build command to execute."
         | {


### PR DESCRIPTION
Substitute with "current" system on Nix side when it's absent. Allows to use the same devshell definition on any system, not just `x86_64-linux`.

Fixes #60