### PR TITLE
Update to latest Nickel

### DIFF
--- a/contracts.ncl
+++ b/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/examples/c-hello-world/nixel/contracts.ncl
+++ b/examples/c-hello-world/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `` 'nix `` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/flake.lock
+++ b/flake.lock
@@ -235,11 +235,11 @@
         "topiary": "topiary"
       },
       "locked": {
-        "lastModified": 1682335909,
-        "narHash": "sha256-E4+08BmxFg2G3QXzzEDh0DvVHUOhz0Q8q3WBGqF6NeI=",
+        "lastModified": 1682514100,
+        "narHash": "sha256-bNv3NlOJqK7L7J7KO0kKFOgLcT4eEu6E7/dwM/JdQiQ=",
         "owner": "tweag",
         "repo": "nickel",
-        "rev": "a5f20ca89f1ae8583e9742e8e8b57b79632929ad",
+        "rev": "913a7c1e12a1811b2c86d1ecae66958ef77520d0",
         "type": "github"
       },
       "original": {
@@ -474,11 +474,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1680178226,
-        "narHash": "sha256-EZtmLYPQII8Ma9yH0udqlNjSXiYUg134j+0Srzb4rbM=",
+        "lastModified": 1682503900,
+        "narHash": "sha256-3Kb9D8S0lkGcPAcpJJGInVyFN79K6gn6TN0ZHWFA19s=",
         "owner": "tweag",
         "repo": "topiary",
-        "rev": "1af03d77abf6aef3ea36f878554c16619207252b",
+        "rev": "773159aa4c819b46c6d51ca9275e7366087eb3a0",
         "type": "github"
       },
       "original": {

--- a/future/playground/acpilight.ncl
+++ b/future/playground/acpilight.ncl
@@ -47,7 +47,7 @@ let Builder = {
      url = "https://gitlab.com/wavexx/acpilight.git",
      rev = "v%{version}",
      sha256 = "1r0r3nx6x6vkpal6vci0zaa1n9dfacypldf6k8fxg7919vzxdn1w",
-     fetchType = `Git,
+     fetchType = 'Git,
   },
 
   vars = {

--- a/templates/devshells/c/nixel/contracts.ncl
+++ b/templates/devshells/c/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/templates/devshells/clojure/nixel/contracts.ncl
+++ b/templates/devshells/clojure/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/templates/devshells/erlang/nixel/contracts.ncl
+++ b/templates/devshells/erlang/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/templates/devshells/go/nixel/contracts.ncl
+++ b/templates/devshells/go/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/templates/devshells/javascript/nixel/contracts.ncl
+++ b/templates/devshells/javascript/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/templates/devshells/php/nixel/contracts.ncl
+++ b/templates/devshells/php/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/templates/devshells/python310/nixel/contracts.ncl
+++ b/templates/devshells/python310/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/templates/devshells/racket/nixel/contracts.ncl
+++ b/templates/devshells/racket/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/templates/devshells/rust/nixel/contracts.ncl
+++ b/templates/devshells/rust/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/templates/devshells/scala/nixel/contracts.ncl
+++ b/templates/devshells/scala/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },

--- a/templates/devshells/zig/nixel/contracts.ncl
+++ b/templates/devshells/zig/nixel/contracts.ncl
@@ -60,12 +60,12 @@ from the Nix world) or a derivation defined in Nickel.
 
   NixSymbolicString
     | doc m%"
-      A symbolic string with the `` `nix `` prefix, as output by the Nickel
+      A symbolic string with the `'nix` prefix, as output by the Nickel
       parser. Used as a subcontract for `NixString`.
       "%
     = {
-    prefix | [| `nix |],
-    tag | [| `SymbolicString |],
+    prefix | [| 'nix |],
+    tag | [| 'SymbolicString |],
     fragments | Array NixString,
   },
 
@@ -151,7 +151,7 @@ from the Nix world) or a derivation defined in Nickel.
       else
         # TODO: it's for debugging, but we should remove the serializing at some
         # point.
-        let label = std.contract.label.append_note (std.serialize `Json value) label in
+        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let {fragments, ..} = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 
@@ -253,7 +253,7 @@ from the Nix world) or a derivation defined in Nickel.
             override `env` directly, be aware that **`structured_env` will then
             be potentially completly ignored**.
           "%%%
-        | {_: {_: NixString}}
+        | {_ | {_ | NixString}}
         | default = {},
       env
         | doc m%"
@@ -264,7 +264,7 @@ from the Nix world) or a derivation defined in Nickel.
           source of truth being passed to Nix when building the derivation. See the
           documentation of `structured_env` for more details.
           "%
-        | {_: NixString}
+        | {_ | NixString}
         # TODO: should we compute `env` from `structured_env` directly here? Or
         # let each builder do that by itself?
         #
@@ -279,7 +279,7 @@ from the Nix world) or a derivation defined in Nickel.
   Params | doc "The parameters provided to the Nickel expression"
     = {
     system | System,
-    inputs | {_: Derivation},
+    inputs | {_ | Derivation},
     nix | {..},
   },
 
@@ -335,7 +335,7 @@ from the Nix world) or a derivation defined in Nickel.
 
   NickelExpression | doc "A Nickel expression"
     = {
-    inputs_spec | {_ : NickelInputSpec},
+    inputs_spec | {_ | NickelInputSpec},
     output | NickelExpressionResult,
     ..
   },


### PR DESCRIPTION
Update to latest Nickel changes upstream, which are:

 - Syntax change from backtick to single quote to delimit enum tags
 - Semantics change of dictionary types, with the introduction of dictionary contracts. The latter should behave the same as the original dictionary type, so the change is mechanical: just change dictionary types to dictionary contracts.