### PR TITLE
Move tests to the flake

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -45,18 +45,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        path: nickel-nix-repo
         fetch-depth: 0
 
     - name: Setup
-      uses: ./nickel-nix-repo/.github/actions/common-setup
+      uses: ./.github/actions/common-setup
       with:
         SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CACHIX_TOKEN: ${{ secrets.CACHIX_TOKEN }}
 
     - name: Build
       run: |
-        cd nickel-nix-repo/examples/${{ matrix.example }}
-        nix flake lock --override-input nickel-nix path:../../
-        nix run .#regenerate-lockfile --accept-flake-config
-        nix build --impure --accept-flake-config
+        nix run .#tests.examples.${{ matrix.example }}

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -45,26 +45,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        path: nickel-nix-repo
         fetch-depth: 0
 
     - name: Setup
-      uses: ./nickel-nix-repo/.github/actions/common-setup
+      uses: ./.github/actions/common-setup
       with:
         SECRET_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CACHIX_TOKEN: ${{ secrets.CACHIX_TOKEN }}
 
-    - name: Initialize devshell ${{ matrix.template }}
+    - name: Test devshell ${{ matrix.template }}
       run: |
-        nix flake new --template path:$PWD/nickel-nix-repo#${{ matrix.template }} example --accept-flake-config
-
-    - name: Enter devshell ${{ matrix.template }}
-      # For the CI, we test against the local version of `nickel-nix`, not the
-      # one in main (hence the --override-input). Note that each template is
-      # tested in a `./example` directory, so `nickel-nix` is the direct parent.
-      run: |
-          pushd ./example
-          nix flake lock --override-input nickel-nix path:$GITHUB_WORKSPACE/nickel-nix-repo --accept-flake-config
-          nix run .#regenerate-lockfile --accept-flake-config
-          nix develop --impure --accept-flake-config --print-build-logs
-          popd
+        nix run .#tests.templates.${{ matrix.template }}


### PR DESCRIPTION
Create "devshell" for each test that can be executed with `nix develop` and call it from GitHub workflows.
This allows to run tests locally with high confidence that they will pass on CI.

Depends on #73