### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '00:00'
+    timezone: UTC
+  open-pull-requests-limit: 10
+  commit-message:
+      prefix: "chore"
+      include: "scope"
+
+- package-ecosystem: github-actions
+  directory: ".github/actions"
+  schedule:
+    interval: daily
+    time: '00:00'
+    timezone: UTC
+  open-pull-requests-limit: 10
+  commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
This would help keep our GitHub actions up-to-date.

We already have old `cachix/install-nix-action` that doesn't accept `github_access_token` parameter and complains about it on every run.