### PR TITLE
Don’t require --impure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
 
                 First run `nix run .#regenerate-lockfile` to fill `nickel.lock.ncl` with proper references.
 
-                Then run `nix develop --impure` to enter the dev shell.
+                Then run `nix develop` to enter the dev shell.
               '';
             }
         )
@@ -217,7 +217,7 @@
                   # We test against the local version of `nickel-nix`, not the one in main (hence the --override-input).
                   nix flake lock --override-input nickel-nix path:${./.} --accept-flake-config
                   nix run .#regenerate-lockfile --accept-flake-config
-                  nix develop --impure --accept-flake-config --print-build-logs < /dev/null
+                  nix develop --accept-flake-config --print-build-logs < /dev/null
                   popd
                 '';
               }
@@ -232,7 +232,7 @@
                   cd ./${name}
                   nix flake lock --override-input nickel-nix path:${./.}
                   nix run .#regenerate-lockfile --accept-flake-config
-                  nix build --impure --accept-flake-config
+                  nix build --accept-flake-config
                 '';
               }
           );


### PR DESCRIPTION
Keep trace of all the derivations encountered during the export so that we don’t have to import them again.

The implementation is really ugly, so not sure whether that’s worth it, but at least it’s possible 💪🏻

Rebased and adapted from https://github.com/thufschmitt/nickel-nix/tree/nicke-shell-pure
Depends on #73 ad #74
Closes #15 