### PR TITLE
Replace substituters with nickel-nix.cachix.org

### DIFF
--- a/examples/c-hello-world/flake.nix
+++ b/examples/c-hello-world/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/c/flake.nix
+++ b/templates/devshells/c/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/clojure/flake.nix
+++ b/templates/devshells/clojure/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/erlang/flake.nix
+++ b/templates/devshells/erlang/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/go/flake.nix
+++ b/templates/devshells/go/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/haskell/flake.nix
+++ b/templates/devshells/haskell/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/javascript/flake.nix
+++ b/templates/devshells/javascript/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/php/flake.nix
+++ b/templates/devshells/php/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/python310/flake.nix
+++ b/templates/devshells/python310/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/racket/flake.nix
+++ b/templates/devshells/racket/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/rust/flake.nix
+++ b/templates/devshells/rust/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/scala/flake.nix
+++ b/templates/devshells/scala/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {

--- a/templates/devshells/zig/flake.nix
+++ b/templates/devshells/zig/flake.nix
@@ -6,14 +6,8 @@
   inputs.nickel-nix.url = "github:nickel-lang/nickel-nix";
 
   nixConfig = {
-    extra-substituters = [
-      "https://tweag-nickel.cachix.org"
-      "https://tweag-topiary.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
-      "tweag-topiary.cachix.org-1:8TKqya43LAfj4qNHnljLpuBnxAY/YwEBfzo3kzXxNY0="
-    ];
+    extra-substituters = ["https://nickel-nix.cachix.org"];
+    extra-trusted-public-keys = ["nickel-nix.cachix.org-1:/Ziozgt3g0CfGwGS795wyjRa9ArE89s3tbz31S6xxFM="];
   };
 
   outputs = {


### PR DESCRIPTION
in all templates and the example.
We push all paths not in cache.nixos.org to nickecl-nix.cachix.org anyway, so no need to keep multiple substituters in flake.nix files.

Don't change nickel-nix flake.nix though, because we don't want to rebuild everything on dependency updates.