### PR TITLE
Update copyright owner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Nickel Lang
+Copyright (c) 2022 Modus Create LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The copyright of the license mentions Nickel Lang, but this entity doesn't really have any legal existence, nor clear definition. It's mostly a GitHub org, for the time being. This PR sets the copyright owner to the company holding Tweag, which is Modus Create LLC, in line with other Tweag repositories.