### PR TITLE
Fix the buildInputs in the shells

### DIFF
--- a/builders.ncl
+++ b/builders.ncl
@@ -302,10 +302,11 @@ in
                 "-c",
                 # Sorry about Topiary formatting of the following lines
                 nix-s%"
+            source .attrs.sh
             export PATH='%{inputs.coreutils}/bin'":$PATH"
-            mkdir -p $out/bin
-            echo "$0" > $out/bin/stack
-            chmod a+x $out/bin/*
+            mkdir -p ${outputs[out]}/bin
+            echo "$0" > ${outputs[out]}/bin/stack
+            chmod a+x ${outputs[out]}/bin/*
           "%,
                 nix-s%"
             #!%{inputs.bash}/bin/bash

--- a/builders.ncl
+++ b/builders.ncl
@@ -70,12 +70,12 @@ in
       Analogous to `mkShell`.
     "%
     = NixpkgsPkg & {
-      packages | doc "Packages to be added to the shell, setting PATH, LD_LIBRARY_PATH and other variables as needed" = {},
       hooks | doc "Bash scripts to run when entering the shell" = {},
 
       output = {
         name | default = "shell",
         version | default = "dev",
+        packages | doc "Packages to be added to the shell, setting PATH, LD_LIBRARY_PATH and other variables as needed" = {},
 
         env.buildCommand = nix-s%"
           echo "This derivation is not supposed to be built" 1>&2 1>/dev/null
@@ -83,7 +83,7 @@ in
         "%,
         env.shellHook = concat_strings_sep "\n" (std.record.values hooks),
         structured_env.buildInputs = packages,
-      } | NickelPkg,
+      } | (NickelPkg & { packages | { _ : Derivation } }),
     },
 
   BashShell = Shell & {


### PR DESCRIPTION
PR #96 accidentally made all the shells empty by giving them an empty `buildInputs` field (oops). This fixes it
