### PR TITLE
Replace `inputs_spec` by an `import_nix` function

### DIFF
--- a/examples/c-hello-world/package.ncl
+++ b/examples/c-hello-world/package.ncl
@@ -1,22 +1,14 @@
 let nickel-nix = (import "./nickel.lock.ncl").nickel-nix in
 
 nickel-nix.builders.NixpkgsPkg & {
-  inputs_spec = {
-    bash.input = "nixpkgs",
-    coreutils.input = "nixpkgs",
-    gcc.input = "nixpkgs",
-  },
-
-  inputs,
-
   output =
     {
       name = "hello",
       version = "0.1",
       structured_env = {
-        buildInputs.gcc = inputs.gcc,
-        buildInputs.coreutils = inputs.coreutils,
-        buildInputs.bash = inputs.bash,
+        buildInputs.gcc = nickel-nix.lib.import_nix "nixpkgs#gcc",
+        buildInputs.coreutils = nickel-nix.lib.import_nix "nixpkgs#coreutils",
+        buildInputs.bash = nickel-nix.lib.import_nix "nixpkgs#bash",
       },
       env = {
         buildCommand = nix-s%"

--- a/lib/builders.ncl
+++ b/lib/builders.ncl
@@ -199,6 +199,7 @@ in
         let stack-wrapped =
           {
             name = "stack-wrapped",
+            # Should be stack.version, but import_nix doesn't allow to access derivation attributes
             version = "1.0",
             build_command = {
               cmd = nix-s%"%{lib.import_nix "nixpkgs#bash"}/bin/bash"%,

--- a/lib/builders.ncl
+++ b/lib/builders.ncl
@@ -1,5 +1,7 @@
 let { NickelDerivation, Derivation, NixString, .. } = import "contracts.ncl" in
 
+let lib = import "lib.ncl" in
+
 let concat_strings_sep = fun sep values =>
   if std.array.length values == 0 then "" else
     std.array.reduce_left (fun acc value => nix-s%"%{acc}%{sep}%{value}"%) values
@@ -44,21 +46,16 @@ in
       Can be controlled with environment variables in the same way as `stdenv.mkDerivation`.
     "%
     = {
-      inputs_spec = {
-        bash.input | default = "nixpkgs",
-        stdenv.input | default = "nixpkgs",
-      },
-      inputs,
       output = {
         name,
         version,
         build_command = {
-          cmd = nix-s%"%{inputs.bash}/bin/bash"%,
+          cmd = nix-s%"%{lib.import_nix "nixpkgs#bash"}/bin/bash"%,
           args = ["-c", "set -euo pipefail; source .attrs.sh; source $stdenv/setup; genericBuild"],
         },
         structured_env = {},
         env = {
-          stdenv = inputs.stdenv,
+          stdenv = lib.import_nix "nixpkgs#stdenv"
         },
         attrs = env & structured_env,
       } | NickelPkg,
@@ -87,76 +84,46 @@ in
     },
 
   BashShell = Shell & {
-    inputs_spec = {
-      bash.input | default = "nixpkgs",
-    },
-    inputs,
     output.packages = {
-      bash = inputs.bash,
+      bash = lib.import_nix "nixpkgs#bash",
     },
   },
 
   RustShell =
     BashShell
     & {
-      inputs_spec = {
-        cargo = {},
-        rustc = {},
-        rustfmt = {},
-        rust-analyzer = {},
-      },
-      inputs,
-
       output.packages = {
-        cargo = inputs.cargo,
-        rustc = inputs.rustc,
-        rustfmt = inputs.rustfmt,
-        rust-analyzer = inputs.rust-analyzer,
+        cargo = lib.import_nix "nixpkgs#cargo",
+        rustc = lib.import_nix "nixpkgs#rustc",
+        rustfmt = lib.import_nix "nixpkgs#rustfmt",
+        rust-analyzer = lib.import_nix "nixpkgs#rust-analyzer",
       },
     },
 
   GoShell =
     BashShell
     & {
-      inputs_spec = {
-        go = {},
-        gopls = {},
-      },
-      inputs,
-
       output.packages = {
-        go = inputs.go,
-        gopls = inputs.gopls,
+        go = lib.import_nix "nixpkgs#go",
+        gopls = lib.import_nix "nixpkgs#gopls",
       },
     },
 
   ClojureShell =
     BashShell
     & {
-      inputs_spec = {
-        clojure = {},
-        clojure-lsp = {},
-      },
-      inputs,
-
       output.packages = {
-        clojure = inputs.clojure,
-        clojure-lsp = inputs.clojure-lsp,
+        clojure = lib.import_nix "nixpkgs#clojure",
+        clojure-lsp = lib.import_nix "nixpkgs#clojure-lsp",
       },
     },
 
   CShell =
     BashShell
     & {
-      inputs_spec = {
-        clang = {},
-        clang-tools = {},
-      },
-      inputs,
-
       output.packages = {
-        clang = inputs.clang,
-        clang-tools = inputs.clang-tools,
+        clang = lib.import_nix "nixpkgs#clang",
+        clang-tools = lib.import_nix "nixpkgs#clang-tools",
       },
     },
 
@@ -164,105 +131,63 @@ in
   PhpShell =
     BashShell
     & {
-      inputs_spec = {
-        php = {},
-      },
-      inputs,
-
       output.packages = {
-        php = inputs.php,
+        php = lib.import_nix "nixpkgs#php",
+        # Not included because unfree
+        # intelephense = lib.import_nix "nixpkgs#nodePackages.intelephense",
       },
     },
 
   ZigShell =
     BashShell
     & {
-      inputs_spec = {
-        zig = {},
-        zls = {},
-      },
-      inputs,
-
       output.packages = {
-        zig = inputs.zig,
-        zls = inputs.zls,
+        zig = lib.import_nix "nixpkgs#zig",
+        zls = lib.import_nix "nixpkgs#zls",
       },
     },
 
   JavascriptShell =
     BashShell
     & {
-      inputs_spec = {
-        nodejs = {},
-        typescript-language-server = {
-          path = "nodePackages_latest.typescript-language-server",
-        }
-      },
-      inputs,
-
       output.packages = {
-        nodejs = inputs.nodejs,
-        ts-lsp = inputs.typescript-language-server,
+        nodejs = lib.import_nix "nixpkgs#nodejs",
+        ts-lsp = lib.import_nix "nixpkgs#nodePackages_latest.typescript-language-server",
       },
     },
 
   RacketShell =
     BashShell
     & {
-      inputs_spec = {
-        racket = {},
-      },
-      inputs,
-
       output.packages = {
-        racket = inputs.racket,
+        racket = lib.import_nix "nixpkgs#racket",
       },
     },
 
   ScalaShell =
     BashShell
     & {
-      inputs_spec = {
-        scala = {},
-        metals = {},
-      },
-      inputs,
-
       output.packages = {
-        scala = inputs.scala,
-        metals = inputs.metals,
+        scala = lib.import_nix "nixpkgs#scala",
+        metals = lib.import_nix "nixpkgs#metals",
       },
     },
 
   Python310Shell =
     BashShell
     & {
-      inputs_spec = {
-        python310 = {},
-        python-lsp-server = {
-          path = "python310Packages.python-lsp-server",
-        }
-      },
-      inputs,
-
       output.packages = {
-        python = inputs.python310,
-        python-lsp = inputs.python-lsp-server,
+        python = lib.import_nix "nixpkgs#python310",
+        python-lsp = lib.import_nix "nixpkgs#python310Packages.python-lsp-server",
       },
     },
 
   ErlangShell =
     BashShell
     & {
-      inputs_spec = {
-        erlang = {},
-        erlang-ls = {},
-      },
-      inputs,
-
       output.packages = {
-        erlang = inputs.erlang,
-        erlang-lsp = inputs.erlang-ls,
+        erlang = lib.import_nix "nixpkgs#erlang",
+        erlang-lsp = lib.import_nix "nixpkgs#erlang-ls",
       },
     },
 
@@ -270,43 +195,29 @@ in
     BashShell
     & {
       ghcVersion | default = "927", # User-defined. To keep in sync with the one used by stack
-      inputs_spec = {
-        stack = {},
-        ormolu = {},
-        nix = {},
-        git = {},
-        coreutils = {},
-        haskell-language-server = {
-          path = "haskell.packages.ghc%{ghcVersion}.haskell-language-server",
-        },
-        # This will point to a copy of nixpkgs in nix store
-        path = {},
-      },
-      inputs,
-
       output.packages =
         let stack-wrapped =
           {
             name = "stack-wrapped",
-            version = inputs.stack.version,
+            version = "1.0",
             build_command = {
-              cmd = nix-s%"%{inputs.bash}/bin/bash"%,
+              cmd = nix-s%"%{lib.import_nix "nixpkgs#bash"}/bin/bash"%,
               args = [
                 "-c",
                 # Sorry about Topiary formatting of the following lines
                 nix-s%"
             source .attrs.sh
-            export PATH='%{inputs.coreutils}/bin'":$PATH"
+            export PATH='%{lib.import_nix "nixpkgs#coreutils"}/bin'":$PATH"
             mkdir -p ${outputs[out]}/bin
             echo "$0" > ${outputs[out]}/bin/stack
             chmod a+x ${outputs[out]}/bin/*
           "%,
                 nix-s%"
-            #!%{inputs.bash}/bin/bash
-            %{inputs.stack}/bin/stack \
+            #!%{lib.import_nix "nixpkgs#bash"}/bin/bash
+            %{lib.import_nix "nixpkgs#stack"}/bin/stack \
               --nix \
               --no-nix-pure \
-              --nix-path="nixpkgs=%{inputs.path}" \
+              --nix-path="nixpkgs=%{lib.import_nix "nixpkgs#path"}" \
               "$@"
           "%,
               ],
@@ -315,11 +226,11 @@ in
         in
         {
           stack = stack-wrapped,
-          stack' = inputs.stack,
-          ormolu = inputs.ormolu,
-          nix = inputs.nix,
-          git = inputs.git,
-          haskell-language-server = inputs.haskell-language-server,
+          stack' = lib.import_nix "nixpkgs#stack",
+          ormolu = lib.import_nix "nixpkgs#ormolu",
+          nix = lib.import_nix "nixpkgs#nix",
+          git = lib.import_nix "nixpkgs#git",
+          haskell-language-server = lib.import_nix "nixpkgs#haskell.packages.ghc%{ghcVersion}.haskell-language-server",
         },
     },
 }

--- a/lib/contracts.ncl
+++ b/lib/contracts.ncl
@@ -6,6 +6,10 @@ let predicate | doc "Various predicates used to define contracts"
       std.is_record x
       && std.record.has_field type_field x
       && x."%{type_field}" == "nixPath",
+    is_nix_input = fun x =>
+      std.is_record x
+      && std.record.has_field type_field x
+      && x."%{type_field}" == "nixInput",
     is_nix_derivation = fun x =>
       std.is_record x
       && std.record.has_field type_field x
@@ -25,6 +29,7 @@ let predicate | doc "Various predicates used to define contracts"
       is_derivation x
       || std.is_string x
       || is_nix_path x
+      || is_nix_input x
   }
   in
 
@@ -324,17 +329,27 @@ from the Nix world) or a derivation defined in Nickel.
         |> std.contract.apply (Array String) label,
 
   NickelInputSpec | doc "The specification of an input in a Nickel expression"
-    = {
-      input
-        | String
-        | default
-        = "nixpkgs",
-      path
-        | InputPath
-        | optional,
-      # TODO: precise contract. We want to allow a path if input == "sources"
-      ..
-    },
+    =
+      let final = {
+        input
+          | String
+          | default
+          = "nixpkgs",
+        path
+          | InputPath
+          | optional,
+        # TODO: precise contract. We want to allow a path if input == "sources"
+        ..
+      } in
+      fun label value =>
+        if std.is_string value then
+          let splitted = std.contract.apply InputPath label value in
+          {
+            input = std.array.first splitted,
+            pkgPath = std.array.drop_first splitted,
+          } |> std.contract.apply final label
+        else
+          std.contract.apply final label value,
 
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
@@ -355,5 +370,9 @@ from the Nix world) or a derivation defined in Nickel.
   NixPath = {
     "%{type_field}" | force = "nixPath",
     path | String,
-  }
+  },
+  NixInput = {
+    "%{type_field}" | force = "nixInput",
+    spec | NickelInputSpec,
+  },
 }

--- a/lib/contracts.ncl
+++ b/lib/contracts.ncl
@@ -10,10 +10,6 @@ let predicate | doc "Various predicates used to define contracts"
       std.is_record x
       && std.record.has_field type_field x
       && x."%{type_field}" == "nixInput",
-    is_nix_derivation = fun x =>
-      std.is_record x
-      && std.record.has_field type_field x
-      && x."%{type_field}" == "nixDerivation",
     is_nix_string = fun value =>
       std.is_record value
       && std.record.has_field type_field value
@@ -24,7 +20,7 @@ let predicate | doc "Various predicates used to define contracts"
       && x."%{type_field}" == "nickelDerivation",
     is_derivation = fun x =>
       is_nickel_derivation x
-      || is_nix_derivation x,
+      || is_nix_input x,
     is_string_fragment = fun x =>
       is_derivation x
       || std.is_string x
@@ -157,13 +153,6 @@ from the Nix world) or a derivation defined in Nickel.
         let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let { fragments, .. } = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
-
-  NixDerivation | doc "A derivation coming from the Nix world"
-    = {
-      drvPath | String,
-      outputName | String,
-      "%{type_field}" | force = "nixDerivation",
-    },
 
   NickelDerivation
     | doc m%"
@@ -340,14 +329,29 @@ from the Nix world) or a derivation defined in Nickel.
           | optional,
         # TODO: precise contract. We want to allow a path if input == "sources"
         ..
-      } in
+      }
+      in
       fun label value =>
         if std.is_string value then
-          let splitted = std.contract.apply InputPath label value in
-          {
-            input = std.array.first splitted,
-            pkgPath = std.array.drop_first splitted,
-          } |> std.contract.apply final label
+          let hashPosition = (std.string.find "#" value).index in
+          let value' =
+            if hashPosition == -1 then
+              { input = value, pkgPath = [] }
+            else
+              {
+                input = std.string.substring 0 hashPosition value,
+                pkgPath =
+                  std.string.split
+                    "."
+                    (
+                      std.string.substring
+                        (hashPosition + 1)
+                        (std.string.length value)
+                        value
+                    ),
+              }
+          in
+          value' |> std.contract.apply final label
         else
           std.contract.apply final label value,
 

--- a/lib/lib.ncl
+++ b/lib/lib.ncl
@@ -1,0 +1,22 @@
+let contracts = import "contracts.ncl" in
+{
+  import_file
+    | String -> contracts.NixPath
+    | doc m%%"
+          Take a path as a string and produce a Nix path, which will be
+          interpreted as a path on the Nix side and added to the store.
+
+          # Example
+
+          ```nickel
+          cmd = s%"
+              %{inputs.gcc}/bin/gcc %{import_file "hello.c"} -o hello
+              %{inputs.coreutils}/bin/mkdir -p $out/bin
+              %{inputs.coreutils}/bin/cp hello $out/bin/hello
+             "%,
+          ```
+        "%%
+    = fun filepath => { path = filepath },
+  import_nix | contracts.NickelInputSpec -> contracts.NixInput
+    = fun x => { spec = x },
+}

--- a/lib/nix.ncl
+++ b/lib/nix.ncl
@@ -1,28 +1,7 @@
 {
   Derivation = contracts.NickelDerivation,
   NickelExpression = contracts.NickelExpression,
-  lib = {
-    import_file
-      | String -> contracts.NixPath
-      | doc m%%"
-          Take a path as a string and produce a Nix path, which will be
-          interpreted as a path on the Nix side and added to the store.
-
-          # Example
-
-          ```nickel
-          cmd = s%"
-              %{inputs.gcc}/bin/gcc %{import_file "hello.c"} -o hello
-              %{inputs.coreutils}/bin/mkdir -p $out/bin
-              %{inputs.coreutils}/bin/cp hello $out/bin/hello
-             "%,
-          ```
-        "%%
-      = fun filepath => { path = filepath },
-    import_nix
-      | contracts.NickelInputSpec -> contracts.NixInput
-      = fun x => { spec = x },
-  },
+  lib = import "lib.ncl",
   builders = import "builders.ncl",
   contracts = import "contracts.ncl",
 }

--- a/lib/nix.ncl
+++ b/lib/nix.ncl
@@ -19,6 +19,9 @@
           ```
         "%%
       = fun filepath => { path = filepath },
+    import_nix
+      | contracts.NickelInputSpec -> contracts.NixInput
+      = fun x => { spec = x },
   },
   builders = import "builders.ncl",
   contracts = import "contracts.ncl",


### PR DESCRIPTION
This makes things much nicer:

- Makes the logic way easier (the diff shows a nice liftoff of the codebase)
- Makes things a bit faster (since we now only call Nickel once rather than twice)
- Makes shells lighter to write and easier to reason about and compose

The downside comes in terms of error messages, since doing a typo in a `nix_import` call leads a a late error on the Nix side that doesn't point to the call site at all.
But it's not that much worse than the current state, so it'll do.

Fix #56 