### PR TITLE
Split the shells into a `build` and `dev` variant

### DIFF
--- a/examples/c-hello-world/package.ncl
+++ b/examples/c-hello-world/package.ncl
@@ -1,16 +1,19 @@
 let inputs = import "./nickel.lock.ncl" in
 let nickel-nix = inputs.nickel-nix in
 
-nickel-nix.builders.NixpkgsPkg & {
-  output =
-    {
+{
+  packages."default" = packages.hello,
+  packages.hello =
+    nickel-nix.builders.NixpkgsPkg
+    & {
       name = "hello",
       version = "0.1",
       nix_drv = {
         buildInputs.gcc = nickel-nix.lib.import_nix "nixpkgs#gcc",
         buildInputs.coreutils = nickel-nix.lib.import_nix "nixpkgs#coreutils",
         buildInputs.bash = nickel-nix.lib.import_nix "nixpkgs#bash",
-        buildCommand = nix-s%"
+        buildCommand =
+          nix-s%"
           gcc %{nickel-nix.lib.import_file "hello.c"} -o hello
           mkdir -p $out/bin
           cp hello $out/bin/hello

--- a/flake.nix
+++ b/flake.nix
@@ -62,12 +62,12 @@
             builtins.readDir
             (nixpkgs.lib.mapAttrsToList (name: value:
               {
-                "dev-shell.ncl" = nixpkgs.lib.nameValuePair "devShells" {
-                  default = lib.importNcl path name inputs;
-                };
-                "package.ncl" = nixpkgs.lib.nameValuePair "packages" {
-                  default = lib.importNcl path name inputs;
-                };
+                "dev-shell.ncl" = nixpkgs.lib.nameValuePair
+                  "devShells"
+                  (lib.importNcl path name inputs).shells;
+                "package.ncl" = nixpkgs.lib.nameValuePair
+                  "packages"
+                  { fromNickel = (lib.importNcl path name inputs).packages; };
               }
               .${name}
               or []))

--- a/lib/builders.ncl
+++ b/lib/builders.ncl
@@ -45,7 +45,6 @@ in
       Can be controlled with environment variables in the same way as `stdenv.mkDerivation`.
     "%
     = {
-      output = {
         name,
         version,
         build_command = {
@@ -58,7 +57,6 @@ in
         },
         nix_drv = env & structured_env,
       } | NickelPkg,
-    },
 
   Shell
     | doc m%"
@@ -66,9 +64,8 @@ in
       Analogous to `mkShell`.
     "%
     = NixpkgsPkg & {
-      hooks | doc "Bash scripts to run when entering the shell" = {},
+        hooks | doc "Bash scripts to run when entering the shell" = {},
 
-      output = {
         name | default = "shell",
         version | default = "dev",
         packages | doc "Packages to be added to the shell, setting PATH, LD_LIBRARY_PATH and other variables as needed" = {},
@@ -80,20 +77,24 @@ in
         env.shellHook = concat_strings_sep "\n" (std.record.values hooks),
         structured_env.buildInputs = packages,
       } | (NickelPkg & { packages | { _ : Derivation } }),
-    },
 
-  BashShell = Shell & {
-    output.packages = {
-      bash = lib.import_nix "nixpkgs#bash",
+  BashShell = {
+    build = Shell & {
+      packages = {
+        bash = lib.import_nix "nixpkgs#bash",
+      },
     },
+    dev = build,
   },
 
   RustShell =
     BashShell
     & {
-      output.packages = {
+      build.packages = {
         cargo = lib.import_nix "nixpkgs#cargo",
         rustc = lib.import_nix "nixpkgs#rustc",
+      },
+      dev.packages = {
         rustfmt = lib.import_nix "nixpkgs#rustfmt",
         rust-analyzer = lib.import_nix "nixpkgs#rust-analyzer",
       },
@@ -102,63 +103,51 @@ in
   GoShell =
     BashShell
     & {
-      output.packages = {
-        go = lib.import_nix "nixpkgs#go",
-        gopls = lib.import_nix "nixpkgs#gopls",
-      },
+      build.packages.go = lib.import_nix "nixpkgs#go",
+      dev.packages.gopls = lib.import_nix "nixpkgs#gopls",
     },
 
   ClojureShell =
     BashShell
     & {
-      output.packages = {
-        clojure = lib.import_nix "nixpkgs#clojure",
-        clojure-lsp = lib.import_nix "nixpkgs#clojure-lsp",
-      },
+      build.packages.clojure = lib.import_nix "nixpkgs#clojure",
+      dev.packages.clojure-lsp = lib.import_nix "nixpkgs#clojure-lsp",
     },
 
   CShell =
     BashShell
     & {
-      output.packages = {
-        clang = lib.import_nix "nixpkgs#clang",
-        clang-tools = lib.import_nix "nixpkgs#clang-tools",
-      },
+      build.packages.clang = lib.import_nix "nixpkgs#clang",
+      dev.packages.clang-tools = lib.import_nix "nixpkgs#clang-tools",
     },
 
   # intelephense is currently broken in nixpkgs
   PhpShell =
     BashShell
     & {
-      output.packages = {
-        php = lib.import_nix "nixpkgs#php",
-        # Not included because unfree
-        # intelephense = lib.import_nix "nixpkgs#nodePackages.intelephense",
-      },
+      build.packages.php = lib.import_nix "nixpkgs#php",
+      # Not included because unfree
+      # dev.packages.intelephense = lib.import_nix "nixpkgs#nodePackages.intelephense",
     },
 
   ZigShell =
     BashShell
     & {
-      output.packages = {
-        zig = lib.import_nix "nixpkgs#zig",
-        zls = lib.import_nix "nixpkgs#zls",
-      },
+      build.packages.zig = lib.import_nix "nixpkgs#zig",
+      dev.packages.zls = lib.import_nix "nixpkgs#zls",
     },
 
   JavascriptShell =
     BashShell
     & {
-      output.packages = {
-        nodejs = lib.import_nix "nixpkgs#nodejs",
-        ts-lsp = lib.import_nix "nixpkgs#nodePackages_latest.typescript-language-server",
-      },
+      build.packages.nodejs = lib.import_nix "nixpkgs#nodejs",
+      dev.packages.ts-lsp = lib.import_nix "nixpkgs#nodePackages_latest.typescript-language-server",
     },
 
   RacketShell =
     BashShell
     & {
-      output.packages = {
+      build.packages = {
         racket = lib.import_nix "nixpkgs#racket",
       },
     },
@@ -166,35 +155,29 @@ in
   ScalaShell =
     BashShell
     & {
-      output.packages = {
-        scala = lib.import_nix "nixpkgs#scala",
-        metals = lib.import_nix "nixpkgs#metals",
-      },
+      build.packages.scala = lib.import_nix "nixpkgs#scala",
+      dev.packages.metals = lib.import_nix "nixpkgs#metals",
     },
 
   Python310Shell =
     BashShell
     & {
-      output.packages = {
-        python = lib.import_nix "nixpkgs#python310",
-        python-lsp = lib.import_nix "nixpkgs#python310Packages.python-lsp-server",
-      },
+      build.packages.python = lib.import_nix "nixpkgs#python310",
+      dev.packages.python-lsp = lib.import_nix "nixpkgs#python310Packages.python-lsp-server",
     },
 
   ErlangShell =
     BashShell
     & {
-      output.packages = {
-        erlang = lib.import_nix "nixpkgs#erlang",
-        erlang-lsp = lib.import_nix "nixpkgs#erlang-ls",
-      },
+      build.packages.erlang = lib.import_nix "nixpkgs#erlang",
+      dev.packages.erlang-lsp = lib.import_nix "nixpkgs#erlang-ls",
     },
 
   HaskellStackShell =
     BashShell
     & {
-      ghcVersion | default = "927", # User-defined. To keep in sync with the one used by stack
-      output.packages =
+      build.ghcVersion | default = "927", # User-defined. To keep in sync with the one used by stack
+      build.packages =
         let stack-wrapped =
           {
             name = "stack-wrapped",
@@ -227,10 +210,13 @@ in
         {
           stack = stack-wrapped,
           stack' = lib.import_nix "nixpkgs#stack",
-          ormolu = lib.import_nix "nixpkgs#ormolu",
           nix = lib.import_nix "nixpkgs#nix",
           git = lib.import_nix "nixpkgs#git",
-          haskell-language-server = lib.import_nix "nixpkgs#haskell.packages.ghc%{ghcVersion}.haskell-language-server",
+        },
+        dev.ghcVersion,
+        dev.packages = {
+          ormolu = lib.import_nix "nixpkgs#ormolu",
+          haskell-language-server = lib.import_nix "nixpkgs#haskell.packages.ghc%{dev.ghcVersion}.haskell-language-server",
         },
     },
 }

--- a/lib/contracts.ncl
+++ b/lib/contracts.ncl
@@ -292,6 +292,12 @@ from the Nix world) or a derivation defined in Nickel.
     path | String,
   },
 
+  NixelShells = {
+    dev | NickelDerivation = build,
+    build | NickelDerivation,
+    "default" | NickelDerivation = dev,
+  },
+
   # TODO: have the actual contract for the result of an expression. It's pretty
   # open (could be an integer, a derivation, a record of derivations, etc.) but
   # it still obeys some rules: if the `type` field is set to a known predefined
@@ -299,6 +305,11 @@ from the Nix world) or a derivation defined in Nickel.
   #
   # The contract must be: what the Nix side of the code can "parse" without
   # erroring out.
-  NixelExpression = Dyn,
+  NixelExpression = {
+    shells
+      | NixelShells
+      | optional,
+    ..
+  },
 
 }

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -89,7 +89,7 @@
       let nickel_expr | nix.contracts.NixelExpression =
         import "${sources}/${nickelFile}" in
 
-      (nickel_expr & params).output
+      nickel_expr & params
     '';
   in
     nickelWithImports;

--- a/run-test.sh
+++ b/run-test.sh
@@ -67,7 +67,7 @@ test_example () (
   cp -r "$examplePath" ./example
   pushd ./example
   prepare_shell
-  nix build --print-build-logs
+  nix build --print-build-logs .#fromNickel.default
   popd
   popd
 )

--- a/templates/default/dev-shell.ncl
+++ b/templates/default/dev-shell.ncl
@@ -2,8 +2,5 @@ let inputs = import "./nickel.lock.ncl" in
 let nickel-nix = inputs.nickel-nix in
 
 {
-  output = {
-    name = "nickel-shell",
-  }
+  shells = nickel-nix.builders.BashShell
 }
-& nickel-nix.builders.BashShell


### PR DESCRIPTION
Rather than exposing a single shell under `output`, split them between
- `dev` (the default one)
- `build` (a trimmed-down version of `dev` for contexts where we just want to build things and don't need all the dev helpers).

 Depends on #101
