### PR TITLE
Separate the builders and the shells

### DIFF
--- a/lib/builders.ncl
+++ b/lib/builders.ncl
@@ -63,7 +63,9 @@ in
       A derivation that is to be used as a shell, e.g. with `nix develop`.
       Analogous to `mkShell`.
     "%
-    = NixpkgsPkg & {
+    =
+      NixpkgsPkg
+      & {
         hooks | doc "Bash scripts to run when entering the shell" = {},
 
         name | default = "shell",
@@ -76,147 +78,6 @@ in
         "%,
         env.shellHook = concat_strings_sep "\n" (std.record.values hooks),
         structured_env.buildInputs = packages,
-      } | (NickelPkg & { packages | { _ : Derivation } }),
-
-  BashShell = {
-    build = Shell & {
-      packages = {
-        bash = lib.import_nix "nixpkgs#bash",
-      },
-    },
-    dev = build,
-  },
-
-  RustShell =
-    BashShell
-    & {
-      build.packages = {
-        cargo = lib.import_nix "nixpkgs#cargo",
-        rustc = lib.import_nix "nixpkgs#rustc",
-      },
-      dev.packages = {
-        rustfmt = lib.import_nix "nixpkgs#rustfmt",
-        rust-analyzer = lib.import_nix "nixpkgs#rust-analyzer",
-      },
-    },
-
-  GoShell =
-    BashShell
-    & {
-      build.packages.go = lib.import_nix "nixpkgs#go",
-      dev.packages.gopls = lib.import_nix "nixpkgs#gopls",
-    },
-
-  ClojureShell =
-    BashShell
-    & {
-      build.packages.clojure = lib.import_nix "nixpkgs#clojure",
-      dev.packages.clojure-lsp = lib.import_nix "nixpkgs#clojure-lsp",
-    },
-
-  CShell =
-    BashShell
-    & {
-      build.packages.clang = lib.import_nix "nixpkgs#clang",
-      dev.packages.clang-tools = lib.import_nix "nixpkgs#clang-tools",
-    },
-
-  # intelephense is currently broken in nixpkgs
-  PhpShell =
-    BashShell
-    & {
-      build.packages.php = lib.import_nix "nixpkgs#php",
-      # Not included because unfree
-      # dev.packages.intelephense = lib.import_nix "nixpkgs#nodePackages.intelephense",
-    },
-
-  ZigShell =
-    BashShell
-    & {
-      build.packages.zig = lib.import_nix "nixpkgs#zig",
-      dev.packages.zls = lib.import_nix "nixpkgs#zls",
-    },
-
-  JavascriptShell =
-    BashShell
-    & {
-      build.packages.nodejs = lib.import_nix "nixpkgs#nodejs",
-      dev.packages.ts-lsp = lib.import_nix "nixpkgs#nodePackages_latest.typescript-language-server",
-    },
-
-  RacketShell =
-    BashShell
-    & {
-      build.packages = {
-        racket = lib.import_nix "nixpkgs#racket",
-      },
-    },
-
-  ScalaShell =
-    BashShell
-    & {
-      build.packages.scala = lib.import_nix "nixpkgs#scala",
-      dev.packages.metals = lib.import_nix "nixpkgs#metals",
-    },
-
-  Python310Shell =
-    BashShell
-    & {
-      build.packages.python = lib.import_nix "nixpkgs#python310",
-      dev.packages.python-lsp = lib.import_nix "nixpkgs#python310Packages.python-lsp-server",
-    },
-
-  ErlangShell =
-    BashShell
-    & {
-      build.packages.erlang = lib.import_nix "nixpkgs#erlang",
-      dev.packages.erlang-lsp = lib.import_nix "nixpkgs#erlang-ls",
-    },
-
-  HaskellStackShell =
-    BashShell
-    & {
-      build.ghcVersion | default = "927", # User-defined. To keep in sync with the one used by stack
-      build.packages =
-        let stack-wrapped =
-          {
-            name = "stack-wrapped",
-            # Should be stack.version, but import_nix doesn't allow to access derivation attributes
-            version = "1.0",
-            build_command = {
-              cmd = nix-s%"%{lib.import_nix "nixpkgs#bash"}/bin/bash"%,
-              args = [
-                "-c",
-                # Sorry about Topiary formatting of the following lines
-                nix-s%"
-            source .attrs.sh
-            export PATH='%{lib.import_nix "nixpkgs#coreutils"}/bin'":$PATH"
-            mkdir -p ${outputs[out]}/bin
-            echo "$0" > ${outputs[out]}/bin/stack
-            chmod a+x ${outputs[out]}/bin/*
-          "%,
-                nix-s%"
-            #!%{lib.import_nix "nixpkgs#bash"}/bin/bash
-            %{lib.import_nix "nixpkgs#stack"}/bin/stack \
-              --nix \
-              --no-nix-pure \
-              --nix-path="nixpkgs=%{lib.import_nix "nixpkgs#path"}" \
-              "$@"
-          "%,
-              ],
-            },
-          } | NickelPkg
-        in
-        {
-          stack = stack-wrapped,
-          stack' = lib.import_nix "nixpkgs#stack",
-          nix = lib.import_nix "nixpkgs#nix",
-          git = lib.import_nix "nixpkgs#git",
-        },
-        dev.ghcVersion,
-        dev.packages = {
-          ormolu = lib.import_nix "nixpkgs#ormolu",
-          haskell-language-server = lib.import_nix "nixpkgs#haskell.packages.ghc%{dev.ghcVersion}.haskell-language-server",
-        },
-    },
+      }
+        | (NickelPkg & { packages | { _ : Derivation } }),
 }

--- a/lib/nix.ncl
+++ b/lib/nix.ncl
@@ -2,6 +2,7 @@
   lib = import "lib.ncl",
   builders = import "builders.ncl",
   contracts = import "contracts.ncl",
+  shells = import "shells.ncl",
 }
 #TODO: currently, Nickel forbids doc at the toplevel. It's most definitely
 # temporary, as the implementation of RFC005 is ongoing. Once the capability is

--- a/lib/shells.ncl
+++ b/lib/shells.ncl
@@ -1,0 +1,156 @@
+let builders = import "builders.ncl" in
+let contracts = import "contracts.ncl" in
+let lib = import "lib.ncl" in
+
+let concat_strings_sep = fun sep values =>
+  if std.array.length values == 0 then
+    ""
+  else
+    std.array.reduce_left (fun acc value => nix-s%"%{acc}%{sep}%{value}"%) values
+in
+
+{
+  Bash = {
+    build =
+      builders.Shell
+      & {
+        packages = {
+          bash = lib.import_nix "nixpkgs#bash",
+        },
+      },
+    dev = build,
+  },
+
+  Rust =
+    Bash
+    & {
+      build.packages = {
+        cargo = lib.import_nix "nixpkgs#cargo",
+        rustc = lib.import_nix "nixpkgs#rustc",
+      },
+      dev.packages = {
+        rustfmt = lib.import_nix "nixpkgs#rustfmt",
+        rust-analyzer = lib.import_nix "nixpkgs#rust-analyzer",
+      },
+    },
+
+  Go =
+    Bash
+    & {
+      build.packages.go = lib.import_nix "nixpkgs#go",
+      dev.packages.gopls = lib.import_nix "nixpkgs#gopls",
+    },
+
+  Clojure =
+    Bash
+    & {
+      build.packages.clojure = lib.import_nix "nixpkgs#clojure",
+      dev.packages.clojure-lsp = lib.import_nix "nixpkgs#clojure-lsp",
+    },
+
+  C =
+    Bash
+    & {
+      build.packages.clang = lib.import_nix "nixpkgs#clang",
+      dev.packages.clang-tools = lib.import_nix "nixpkgs#clang-tools",
+    },
+
+  # intelephense is currently broken in nixpkgs
+  Php =
+    Bash
+    & {
+      build.packages.php = lib.import_nix "nixpkgs#php",
+      # Not included because unfree
+      # dev.packages.intelephense = lib.import_nix "nixpkgs#nodePackages.intelephense",
+    },
+
+  Zig =
+    Bash
+    & {
+      build.packages.zig = lib.import_nix "nixpkgs#zig",
+      dev.packages.zls = lib.import_nix "nixpkgs#zls",
+    },
+
+  Javascript =
+    Bash
+    & {
+      build.packages.nodejs = lib.import_nix "nixpkgs#nodejs",
+      dev.packages.ts-lsp = lib.import_nix "nixpkgs#nodePackages_latest.typescript-language-server",
+    },
+
+  Racket =
+    Bash
+    & {
+      build.packages = {
+        racket = lib.import_nix "nixpkgs#racket",
+      },
+    },
+
+  Scala =
+    Bash
+    & {
+      build.packages.scala = lib.import_nix "nixpkgs#scala",
+      dev.packages.metals = lib.import_nix "nixpkgs#metals",
+    },
+
+  Python310 =
+    Bash
+    & {
+      build.packages.python = lib.import_nix "nixpkgs#python310",
+      dev.packages.python-lsp = lib.import_nix "nixpkgs#python310Packages.python-lsp-server",
+    },
+
+  Erlang =
+    Bash
+    & {
+      build.packages.erlang = lib.import_nix "nixpkgs#erlang",
+      dev.packages.erlang-lsp = lib.import_nix "nixpkgs#erlang-ls",
+    },
+
+  HaskellStack =
+    Bash
+    & {
+      build.ghcVersion | default = "927", # User-defined. To keep in sync with the one used by stack
+      build.packages =
+        let stack-wrapped =
+          {
+            name = "stack-wrapped",
+            version = "1.0",
+            build_command = {
+              cmd = nix-s%"%{lib.import_nix "nixpkgs#bash"}/bin/bash"%,
+              args = [
+                "-c",
+                # Sorry about Topiary formatting of the following lines
+                nix-s%"
+            source .attrs.sh
+            export PATH='%{lib.import_nix "nixpkgs#coreutils"}/bin'":$PATH"
+            mkdir -p ${outputs[out]}/bin
+            echo "$0" > ${outputs[out]}/bin/stack
+            chmod a+x ${outputs[out]}/bin/*
+          "%,
+                nix-s%"
+            #!%{lib.import_nix "nixpkgs#bash"}/bin/bash
+            %{lib.import_nix "nixpkgs#stack"}/bin/stack \
+              --nix \
+              --no-nix-pure \
+              --nix-path="nixpkgs=%{lib.import_nix "nixpkgs#path"}" \
+              "$@"
+          "%,
+              ],
+            },
+          }
+            | builders.NickelPkg
+        in
+        {
+          stack = stack-wrapped,
+          stack' = lib.import_nix "nixpkgs#stack",
+          nix = lib.import_nix "nixpkgs#nix",
+          git = lib.import_nix "nixpkgs#git",
+        },
+      dev.ghcVersion,
+      dev.packages = {
+        ormolu = lib.import_nix "nixpkgs#ormolu",
+        haskell-language-server = lib.import_nix "nixpkgs#haskell.packages.ghc%{dev.ghcVersion}.haskell-language-server",
+      },
+    },
+}

--- a/run-test.sh
+++ b/run-test.sh
@@ -34,16 +34,13 @@ prepare_shell() {
 # Note: running in a subshell (hence the parens and not braces around the function body) so that the trap-based cleanup happens whenever we exit
 test_one_template () (
   target="$1"
-  if [[ "$target" == NickelPkg ]] || [[ "$target" == "NixpkgsPkg" ]] || [[ "$target" == "Shell" ]]; then
-    exit 0
-  fi
   set -x
   pushd_temp
 
   nix flake new --template "path:$PROJECT_ROOT" example --accept-flake-config
 
   pushd ./example
-  sed -i "s/BashShell/$target/" dev-shell.ncl
+  sed -i "s/shells\.Bash/shells.$target/" dev-shell.ncl
   prepare_shell
   nix develop --accept-flake-config --print-build-logs < /dev/null
   popd
@@ -55,7 +52,7 @@ test_template () {
   if [[ -n ${1+x} ]]; then
     test_one_template "$1"
   else
-    all_targets=$(nickel export --format raw <<<'std.record.fields ((import "lib/nix.ncl").builders) |> std.string.join "\n"')
+    all_targets=$(nickel export --format raw <<<'std.record.fields ((import "lib/nix.ncl").shells) |> std.string.join "\n"')
     echo "$all_targets" | parallel --tag "$0" template
   fi
 }

--- a/templates/default/dev-shell.ncl
+++ b/templates/default/dev-shell.ncl
@@ -2,5 +2,5 @@ let inputs = import "./nickel.lock.ncl" in
 let nickel-nix = inputs.nickel-nix in
 
 {
-  shells = nickel-nix.builders.BashShell
+  shells = nickel-nix.shells.Bash
 }


### PR DESCRIPTION
Expose them under a different namespace.

This makes the API clearer and removes noise from the autocompletion when listing all the shells (because we _only_ see the shells now, not the lower level builders).
